### PR TITLE
fix: categorie servizio

### DIFF
--- a/archive-servizio.php
+++ b/archive-servizio.php
@@ -16,7 +16,7 @@ $args = array(
     's' => $query,
     'posts_per_page' => $max_posts,
     'post_type'      => 'servizio',
-    'categorie_servizio' => $obj->name,
+    'categorie_servizio' => $obj->slug,
     'orderby'        => 'post_title',
     'order'          => 'ASC'
 );
@@ -24,7 +24,7 @@ $the_query = new WP_Query( $args );
 $servizi = $the_query->posts;
 
 $additional_filter = array();
-$additional_filter['categorie_servizio'] = $obj->name;
+$additional_filter['categorie_servizio'] = $obj->slug;
 
 $amministrazione = dci_get_related_unita_amministrative();
 $bandi = dci_get_related_bandi();

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -235,14 +235,14 @@ if(!function_exists("dci_get_grouped_posts_by_term")) {
             'tax_query' => array(
                 array(
                     'taxonomy' => $taxonomy_name,
-                    'field' => 'name',
+                    'field' => 'slug',
                     'terms' => $terms)
             ),
             'orderby' => 'date',
             'order' => 'DESC',
         );
         if (get_class(get_queried_object())== "WP_Post"){
-            $args['post__not_in'] = get_queried_object()->ID;
+            $args['post__not_in'] = array ( get_queried_object()->ID );
         }
         $posts = get_posts($args);
         return $posts;

--- a/template-parts/single/more-posts-carousel.php
+++ b/template-parts/single/more-posts-carousel.php
@@ -8,15 +8,15 @@ $oldpost = $post;
 $argomenti = dci_get_argomenti_of_post();
 if(count($argomenti)) {
 	// estraggo i nomi
-	$arr_ids = array();
+	$arr_slugs = array();
 	foreach ( $argomenti as $item ) {
-		$arr_ids[] = $item->name;
+		$arr_slugs[] = $item->slug;
 	}
   $amount = 10;
-	$amministrazione = dci_get_grouped_posts_by_term('amministrazione', 'argomenti', $arr_ids, $amount);
-	$servizi = dci_get_grouped_posts_by_term('servizi', 'argomenti', $arr_ids, $amount);
-	$documenti = dci_get_grouped_posts_by_term('documenti-e-dati', 'argomenti', $arr_ids, $amount);
-	$notizie = dci_get_grouped_posts_by_term('novita', 'argomenti', $arr_ids, $amount);
+	$amministrazione = dci_get_grouped_posts_by_term('amministrazione', 'argomenti', $arr_slugs, $amount);
+	$servizi = dci_get_grouped_posts_by_term('servizi', 'argomenti', $arr_slugs, $amount);
+	$documenti = dci_get_grouped_posts_by_term('documenti-e-dati', 'argomenti', $arr_slugs, $amount);
+	$notizie = dci_get_grouped_posts_by_term('novita', 'argomenti', $arr_slugs, $amount);
 
 	$posts_found = count($amministrazione) + count($servizi) + count($documenti) + count($notizie);
 

--- a/template-parts/single/more-posts.php
+++ b/template-parts/single/more-posts.php
@@ -8,15 +8,15 @@ $oldpost = $post;
 $argomenti = dci_get_argomenti_of_post();
 if(count($argomenti)) {
 	// estraggo i nomi
-	$arr_ids = array();
+	$arr_slugs = array();
 	foreach ( $argomenti as $item ) {
-		$arr_ids[] = $item->name;
+		$arr_slugs[] = $item->slug;
 	}
   $amount = 4;
-	$amministrazione = dci_get_grouped_posts_by_term('amministrazione', 'argomenti', $arr_ids, $amount);
-	$servizi = dci_get_grouped_posts_by_term('servizi', 'argomenti', $arr_ids, $amount);
-	$documenti = dci_get_grouped_posts_by_term('documenti-e-dati', 'argomenti', $arr_ids, $amount);
-	$notizie = dci_get_grouped_posts_by_term('novita', 'argomenti', $arr_ids, $amount);
+	$amministrazione = dci_get_grouped_posts_by_term('amministrazione', 'argomenti', $arr_slugs, $amount);
+	$servizi = dci_get_grouped_posts_by_term('servizi', 'argomenti', $arr_slugs, $amount);
+	$documenti = dci_get_grouped_posts_by_term('documenti-e-dati', 'argomenti', $arr_slugs, $amount);
+	$notizie = dci_get_grouped_posts_by_term('novita', 'argomenti', $arr_slugs, $amount);
 
 	$posts_found = count($amministrazione) + count($servizi) + count($documenti) + count($notizie);
 


### PR DESCRIPTION
Alcune categorie non mostravano correttamente i servizi associati: ora la ricerca viene effettuata per "slug" e non per "name".