### PR TITLE
Fix in fase di salvataggio di una persona pubblica lo slug veniva val…

### DIFF
--- a/inc/admin/tipologie/tipologia_persona_pubblica.php
+++ b/inc/admin/tipologie/tipologia_persona_pubblica.php
@@ -265,6 +265,7 @@ function dci_persona_pubblica_set_post_title( $data ) {
             $cognome = $_POST['_dci_persona_pubblica_cognome'];
             $title = $nome.' '.$cognome;
             $data['post_title'] =  $title ;
+            unset($data['post_name']);
         }
         
         $descrizione_breve = '';


### PR DESCRIPTION
Fix in fase di salvataggio di una persona pubblica lo slug veniva valorizzato con "bozza-automatica".

Ho risolto aggiungendo una riga di codice nel file **tipologia_persona_pubblica.php**, in particolare nella funzione `dci_persona_pubblica_set_post_title` ho aggiunto `unset($data['post_name']);`

```php
if (isset($_POST['_dci_persona_pubblica_nome']) && isset($_POST['_dci_persona_pubblica_cognome']) ) {
    $nome = $_POST['_dci_persona_pubblica_nome'];
    $cognome = $_POST['_dci_persona_pubblica_cognome'];
    $title = $nome.' '.$cognome;
    $data['post_title'] =  $title ;
    unset($data['post_name']);
}
```

in questo modo si forza WP a gestire il post_name in autonomia e quindi di default associa il valore del title elaborato dalla funzione _sanitize_title_ e eventualmente aggiunge un numero alla fine se esiste un post_name uguale.
