### PR TITLE
fix: navbar sticky bug

### DIFF
--- a/single-evento.php
+++ b/single-evento.php
@@ -80,7 +80,7 @@ get_header();
                 <div class="row border-top row-column-border row-column-menu-left border-light">
                     <aside class="col-lg-4">
                         <div class="cmp-navscroll sticky-top" aria-labelledby="accordion-title-one">
-                            <nav class="navbar it-navscroll-wrapper it-top-navscroll navbar-expand-lg" data-bs-navscroll>
+                            <nav class="navbar it-navscroll-wrapper navbar-expand-lg" data-bs-navscroll>
                                 <div class="navbar-custom" id="navbarNavProgress">
                                     <div class="menu-wrapper">
                                         <div class="link-list-wrapper">


### PR DESCRIPTION
This PR fixes a bug with the sticky navbar which overlays the header on mobile devices.