### PR TITLE
Stemma alternativa per offcanvas

### DIFF
--- a/header.php
+++ b/header.php
@@ -119,7 +119,7 @@ $current_group = dci_get_current_group();
                 </div>
                 <div class="menu-wrapper">
                 <a href="<?php echo home_url(); ?>" aria-label="Vai alla homepage" class="logo-hamburger">
-                    <?php get_template_part("template-parts/common/logo"); ?>
+                    <?php get_template_part("template-parts/common/logo-mobile"); ?>
                   <div class="it-brand-text">
                     <div class="it-brand-title"><?php echo dci_get_option("nome_comune"); ?></div>
                   </div>

--- a/inc/admin/options/opzioni_comune.php
+++ b/inc/admin/options/opzioni_comune.php
@@ -71,14 +71,25 @@ function dci_register_comune_options(){
     ));
 
     $header_options->add_field( array(
-            'id'    => $prefix . 'stemma_comune',
-            'name' => __('Stemma', 'design_comuni_italia' ),
-            'desc' => __( 'Lo stemma del Comune. Si raccomanda di caricare un\'immagine in formato svg' , 'design_comuni_italia' ),
-            'type' => 'file',
-            'query_args'   => array(
-            'type' => array(
-                'image/svg',
-            ))
+        'id'    => $prefix . 'stemma_comune',
+        'name' => __('Stemma', 'design_comuni_italia' ),
+        'desc' => __( 'Lo stemma del Comune. Si raccomanda di caricare un\'immagine in formato svg' , 'design_comuni_italia' ),
+        'type' => 'file',
+        'query_args'   => array(
+        'type' => array(
+            'image/svg',
+        ))
+    ));
+
+    $header_options->add_field( array(
+        'id'    => $prefix . 'stemma_comune_mobile',
+        'name' => __('Stemma per mobile', 'design_comuni_italia' ),
+        'desc' => __( 'Utilizzare questo campo per caricare un\'immagine alternativa dello stemma del Comune visibile dal menu hamburger (mobile). Si raccomanda di caricare un\'immagine in formato svg' , 'design_comuni_italia' ),
+        'type' => 'file',
+        'query_args'   => array(
+        'type' => array(
+            'image/svg',
+        ))
     ));
 
 }

--- a/template-parts/common/logo-mobile.php
+++ b/template-parts/common/logo-mobile.php
@@ -1,0 +1,7 @@
+<?php
+if (dci_get_option("stemma_comune_mobile")) {
+?>
+<svg width="48" height="48" aria-hidden="true">       
+     <image xlink:href="<?php echo dci_get_option("stemma_comune_mobile");?>" width="48" height="48"/>
+</svg>
+<?php } ?>


### PR DESCRIPTION
Aggiunta nuova funzionalità per l'inserimento di un'immagine alternativa dello stemma del comune per offcanvas.
Fix #107 