### PR TITLE
Ordine novità in Esplora tutte le novità

### DIFF
--- a/inc/utils.php
+++ b/inc/utils.php
@@ -926,6 +926,28 @@ if(!function_exists("dci_get_data_pubblicazione_arr")) {
     }
 }
 
+
+/**
+ * Returns the post_date in timestamp format of a post
+ * @param  string  $key
+ * @param  string  $prefix
+ * @param  int     $post_id
+ * @return string
+ */
+if(!function_exists("dci_get_data_pubblicazione_ts")) {
+    function dci_get_data_pubblicazione_ts($key = '', $prefix = '', $post_id) {
+        global $post;
+        if (!$post) $post = get_post($post_id);
+
+        $data_pubblicazione = dci_get_meta($key, $prefix , $post_id);
+        if (!$data_pubblicazione) {
+        $data_pubblicazione = strtotime(explode(' ',$post->post_date)[0]);
+        }
+        return $data_pubblicazione;
+    }
+}
+
+
 /**
  * Returns the a formatted version of punto-contatto from id
  * @param  int     $post_id

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -917,8 +917,8 @@ if(!function_exists("dci_get_data_pubblicazione_arr")) {
 
         $data_pubblicazione = dci_get_meta($key, $prefix , $post_id);
         if (!$data_pubblicazione) {
-        $data_pubblicazione = explode(' ',$post->post_date)[0];
-        $arrdata =  array_reverse(explode("-", $data_pubblicazione));
+            $data_pubblicazione = explode(' ',$post->post_date)[0];
+            $arrdata =  array_reverse(explode("-", $data_pubblicazione));
         } else {
             $arrdata =  explode("-", date('d-m-y',$data_pubblicazione));  
         }
@@ -941,7 +941,7 @@ if(!function_exists("dci_get_data_pubblicazione_ts")) {
 
         $data_pubblicazione = dci_get_meta($key, $prefix , $post_id);
         if (!$data_pubblicazione) {
-        $data_pubblicazione = strtotime(explode(' ',$post->post_date)[0]);
+            $data_pubblicazione = strtotime(explode(' ',$post->post_date)[0]);
         }
         return $data_pubblicazione;
     }

--- a/template-parts/novita/tutte-novita.php
+++ b/template-parts/novita/tutte-novita.php
@@ -5,17 +5,25 @@ global $the_query, $load_posts, $load_card_type;
     $load_posts = 3;
     $query = isset($_GET['search']) ? $_GET['search'] : null;
     $args = array(
-        's' => $query,
-        'posts_per_page' => $max_posts,
-        'post_type'      => 'notizia'
-     );
-     $the_query = new WP_Query( $args );
+        's'         => $query,
+        'post_type' => 'notizia'
+    );
 
-     $posts = $the_query->posts;
+    $the_query = new WP_Query( $args );
+    $posts = $the_query->posts;
 
     usort($posts, function($a, $b) {
         return dci_get_data_pubblicazione_ts("data_pubblicazione", '_dci_notizia_', $b->ID) - dci_get_data_pubblicazione_ts("data_pubblicazione", '_dci_notizia_', $a->ID);
     });
+    $posts = array_slice($posts, 0, $max_posts);
+
+    $args = array(
+        's'                 => $query,
+        'posts_per_page'    => $max_posts,
+        'post_type'         => 'notizia'
+    );
+
+    $the_query = new WP_Query( $args );
 ?>
 
 

--- a/template-parts/novita/tutte-novita.php
+++ b/template-parts/novita/tutte-novita.php
@@ -7,9 +7,7 @@ global $the_query, $load_posts, $load_card_type;
     $args = array(
         's' => $query,
         'posts_per_page' => $max_posts,
-        'post_type'      => 'notizia',
-        'orderby'        => 'post_title',
-        'order'          => 'ASC'
+        'post_type'      => 'notizia'
      );
      $the_query = new WP_Query( $args );
 

--- a/template-parts/novita/tutte-novita.php
+++ b/template-parts/novita/tutte-novita.php
@@ -14,6 +14,12 @@ global $the_query, $load_posts, $load_card_type;
      $the_query = new WP_Query( $args );
 
      $posts = $the_query->posts;
+
+    usort($posts, function($a, $b) {
+        $a_ts = dci_get_data_pubblicazione_ts("data_pubblicazione", '_dci_notizia_', $a->ID);
+        $b_ts = dci_get_data_pubblicazione_ts("data_pubblicazione", '_dci_notizia_', $b->ID);
+        return $a_ts < $b_ts;
+    });
 ?>
 
 

--- a/template-parts/novita/tutte-novita.php
+++ b/template-parts/novita/tutte-novita.php
@@ -14,9 +14,7 @@ global $the_query, $load_posts, $load_card_type;
      $posts = $the_query->posts;
 
     usort($posts, function($a, $b) {
-        $a_ts = dci_get_data_pubblicazione_ts("data_pubblicazione", '_dci_notizia_', $a->ID);
-        $b_ts = dci_get_data_pubblicazione_ts("data_pubblicazione", '_dci_notizia_', $b->ID);
-        return $a_ts < $b_ts;
+        return dci_get_data_pubblicazione_ts("data_pubblicazione", '_dci_notizia_', $b->ID) - dci_get_data_pubblicazione_ts("data_pubblicazione", '_dci_notizia_', $a->ID);
     });
 ?>
 


### PR DESCRIPTION
All'interno di inc/utils.php ho creato una funzione per recuperare il timestamp delle novità _dci_get_data_pubblicazione_ts_ in modo da poter ordinare i post nel file template-parts/novita/tutte-novita.php
Questa PR fa riferimento alla issue #17 