### PR TITLE
Update prenota-appuntamento.php per fix di warnings

### DIFF
--- a/page-templates/prenota-appuntamento.php
+++ b/page-templates/prenota-appuntamento.php
@@ -9,8 +9,8 @@ global $post;
 
 function dci_enqueue_dci_booking_script()  {
     wp_enqueue_script( 'dci-booking', get_template_directory_uri() . '/assets/js/booking.js', array(), false, true);
-    wp_localize_script('dci-booking', "url", get_template_directory_uri() . '/assets/json/calendar.json');
-    wp_localize_script('dci-booking', "urlConfirm", admin_url( 'admin-ajax.php' ));
+    wp_localize_script('dci-booking', "url", [get_template_directory_uri() . '/assets/json/calendar.json']);
+    wp_localize_script('dci-booking', "urlConfirm", [admin_url( 'admin-ajax.php' )]);
 }
 add_action( 'wp_enqueue_scripts', 'dci_enqueue_dci_booking_script' );
 


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->

Con il codice attuale si ottengono due warnings

Notice: La funzione WP_Scripts::localize è stata richiamata in maniera scorretta. Il parametro $l10n deve essere un array. Per passare dati arbitrari agli script, usa la funzione wp_add_inline_script(). Leggi [Debugging in WordPress](https://wordpress.org/documentation/article/debugging-in-wordpress/) per maggiori informazioni. (Questo messaggio è stato aggiunto nella versione 5.7.0.) in /home/au2yb3ls/pnrr.mlabvda.it/wp-includes/functions.php on line 5865

Notice: La funzione WP_Scripts::localize è stata richiamata in maniera scorretta. Il parametro $l10n deve essere un array. Per passare dati arbitrari agli script, usa la funzione wp_add_inline_script(). Leggi [Debugging in WordPress](https://wordpress.org/documentation/article/debugging-in-wordpress/) per maggiori informazioni. (Questo messaggio è stato aggiunto nella versione 5.7.0.) in /home/au2yb3ls/pnrr.mlabvda.it/wp-includes/functions.php on line 5865

Variando nel template le linee indicate il messaggio di warning è risolto dalla corretta chiamata che come terzo argomento richiede un array

https://developer.wordpress.org/reference/functions/wp_localize_script/