### PR TITLE
fix: form inputs slash bug

### DIFF
--- a/archive-servizio.php
+++ b/archive-servizio.php
@@ -11,7 +11,7 @@ global $obj, $the_query, $load_posts, $load_card_type, $servizio, $additional_fi
 
 $max_posts = isset($_GET['max_posts']) ? $_GET['max_posts'] : 3;
 $load_posts = 3;
-$query = isset($_GET['search']) ? $_GET['search'] : null;
+$query = isset($_GET['search']) ? dci_removeslashes($_GET['search']) : null;
 $args = array(
     's' => $query,
     'posts_per_page' => $max_posts,

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -1133,3 +1133,13 @@ if(!function_exists("dci_get_img")) {
         echo $img;
     }
 }
+
+//Fix relativo issue #262
+//Ad ogni invio del form lo "slash" viene moltiplicato (es. primo invio: /, secondo invio: //, terzo invio: ////, quarto invio: ////////), fino al raggiungimento del limite massimo previsto dal webserver per il metodo GET.
+
+if(!function_exists("dci_removeslashes")) {
+    function dci_removeslashes($string) { 
+        $string=implode("",explode("\\",$string)); 
+        return stripslashes(trim($string)); 
+    }
+}

--- a/page-templates/domande-frequenti.php
+++ b/page-templates/domande-frequenti.php
@@ -9,7 +9,7 @@ global $the_query, $load_posts, $load_card_type, $label, $label_no_more, $classe
 
 $max_posts = isset($_GET['max_posts']) ? $_GET['max_posts'] : 20;
 $load_posts = 10;
-$query = isset($_GET['search']) ? $_GET['search'] : null;
+$query = isset($_GET['search']) ? dci_removeslashes($_GET['search']) : null;
 $args = array(
     's' => $query,
     'posts_per_page' => $max_posts,

--- a/template-parts/documento/tutti-documenti.php
+++ b/template-parts/documento/tutti-documenti.php
@@ -3,7 +3,7 @@ global $the_query, $load_posts, $load_card_type;
 
     $max_posts = isset($_GET['max_posts']) ? $_GET['max_posts'] : 3;
     $load_posts = 3;
-    $query = isset($_GET['search']) ? $_GET['search'] : null;
+    $query = isset($_GET['search']) ? dci_removeslashes($_GET['search']) : null;
     $args = array(
         's' => $query,
         'posts_per_page' => $max_posts,

--- a/template-parts/novita/tutte-novita.php
+++ b/template-parts/novita/tutte-novita.php
@@ -3,7 +3,7 @@ global $the_query, $load_posts, $load_card_type;
 
     $max_posts = isset($_GET['max_posts']) ? $_GET['max_posts'] : 3;
     $load_posts = 3;
-    $query = isset($_GET['search']) ? $_GET['search'] : null;
+    $query = isset($_GET['search']) ? dci_removeslashes($_GET['search']) : null;
     $args = array(
         's'         => $query,
         'post_type' => 'notizia'

--- a/template-parts/search/more-results.php
+++ b/template-parts/search/more-results.php
@@ -19,7 +19,7 @@ if ( !$post_types ) $post_types = dci_get_sercheable_tipologie();
 
 $post_types = json_encode( $post_types );
 
-$query_search = isset($_GET['search']) ? $_GET['search'] : null;
+$query_search = isset($_GET['search']) ? dci_removeslashes($_GET['search']) : null;
 $query_params = '?post_count='.$the_query->post_count.'&load_posts='.$load_posts.'&search='.$query_search.'&post_types='.$post_types.'&load_card_type='.$load_card_type.'&query_params='.$query_params.'&additional_filter='.$additional_filter;
 
 if($the_query->post_count < $the_query->found_posts) {

--- a/template-parts/servizio/tutti-servizi.php
+++ b/template-parts/servizio/tutti-servizi.php
@@ -3,7 +3,7 @@
 
     $max_posts = isset($_GET['max_posts']) ? $_GET['max_posts'] : 3;
     $load_posts = 3;
-    $query = isset($_GET['search']) ? $_GET['search'] : null;
+    $query = isset($_GET['search']) ? dci_removeslashes($_GET['search']) : null;
     $args = array(
         's' => $query,
         'posts_per_page' => $max_posts,


### PR DESCRIPTION
C'è un comportamento inusuale in alcuni form del tema.

Il carattere slash "/" viene moltiplicato nel campo di immissione ad ogni Invio del form di ricerca.

Ad ogni invio del form lo "slash" viene moltiplicato (es. primo invio: /, secondo invio: //, terzo invio: ////, quarto invio: ////////), fino al raggiungimento del limite massimo previsto dal webserver per il metodo GET.

Il valore viene restituito nel form senza escaping, pur essendo il GET filtrato dalla funzione add_slashes di PHP, presente in wp_magic_quotes.

Step per riprodurre:

Immettere il carattere slash "/" e inviare il form.
Nel campo di immissione verrà mostrato lo slash "/" duplicato più e più volte, fino a eventuale errore e interruzione da parte del webserver (es. Error URI Request Too Large).

vedasi 
https://github.com/italia/design-comuni-wordpress-theme/issues/262