### PR TITLE
json-ld in single-servizio: correzioni php tag e validazione

### DIFF
--- a/single-servizio.php
+++ b/single-servizio.php
@@ -71,21 +71,27 @@ get_header();
                     "serviceOperator": {
                         "name": "<?php echo esc_js($ipa); ?>"
                     },
+                    <?php if ( !empty($copertura_geografica) ) : ?>
                     "areaServed": {
                         "name": "<?php echo convertToPlain($copertura_geografica); ?>"
                     },
+                    <?php endif; ?>
                     "audience": {
                         "name": "<?php echo convertToPlain($destinatari); ?>"
                     },
                     "availableChannel": {
+                        <?php if ( !empty($canale_digitale_link) ) : ?>
                         "serviceUrl": "<?php echo esc_js($canale_digitale_link); ?>",
+                        <?php endif; ?>
                         <?php if ( !empty($ufficio) ) : ?>
                         "serviceLocation": {
                             "name": "<?php echo esc_js($ufficio->post_title); ?>",
                             "address": {
-                            "streetAddress": "<?php echo esc_js($indirizzo); ?>",
-                            "postalCode": "<?php echo esc_js($cap); ?>",
-                            "addressLocality": "<?php echo esc_js($quartiere); ?>"
+                                "streetAddress": "<?php echo esc_js($indirizzo); ?>",
+                                "postalCode": "<?php echo esc_js($cap); ?>"
+                                <?php if ( !empty($quartiere) ) : ?>,
+                                "addressLocality": "<?php echo esc_js($quartiere); ?>"
+                                <?php endif; ?>
                             }
                         }
                         <?php endif; ?>

--- a/single-servizio.php
+++ b/single-servizio.php
@@ -66,27 +66,29 @@ get_header();
             };
             ?>
             <script type="application/ld+json" data-element="metatag">{
-                    "name": "<?= $post->post_title; ?>",
-                    "serviceType": "<?= $categoria_servizio; ?>",
+                    "name": "<?php echo esc_js($post->post_title); ?>",
+                    "serviceType": "<?php echo esc_js($categoria_servizio); ?>",
                     "serviceOperator": {
-                        "name": "<?= $ipa; ?>"
+                        "name": "<?php echo esc_js($ipa); ?>"
                     },
                     "areaServed": {
-                        "name": "<?= convertToPlain($copertura_geografica); ?>"
+                        "name": "<?php echo convertToPlain($copertura_geografica); ?>"
                     },
                     "audience": {
-                        "name": "<?= convertToPlain($destinatari); ?>"
+                        "name": "<?php echo convertToPlain($destinatari); ?>"
                     },
                     "availableChannel": {
-                        "serviceUrl": "<?= $canale_digitale_link; ?>",
+                        "serviceUrl": "<?php echo esc_js($canale_digitale_link); ?>",
+                        <?php if ( !empty($ufficio) ) : ?>
                         "serviceLocation": {
-                            "name": "<?= $ufficio->post_title; ?>",
+                            "name": "<?php echo esc_js($ufficio->post_title); ?>",
                             "address": {
-                            "streetAddress": "<?= $indirizzo; ?>",
-                            "postalCode": "<?= $cap; ?>",
-                            "addressLocality": "<?= $quartiere; ?>"
+                            "streetAddress": "<?php echo esc_js($indirizzo); ?>",
+                            "postalCode": "<?php echo esc_js($cap); ?>",
+                            "addressLocality": "<?php echo esc_js($quartiere); ?>"
                             }
                         }
+                        <?php endif; ?>
                     }
             }</script>
             <div class="container" id="main-container">


### PR DESCRIPTION
## Descrizione

Nel template single-servizio.php, i metadati json-ld usano il tag php abbreviato "<?=".
Sostituiti con il tag completo "<?php echo..."
Ragione:
Gli short open tag php non sono sempre attivi, e anzi nelle installazioni WordPress dovrebbero essere sempre disattivati, perché esplicitamente contro i [coding standard](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#no-shorthand-php-tags).
Questo causa che i valori dei campi non vengano sempre visualizzati.
#261

Per alcuni campi opzionali, quando non compilati, è bene omettere l'intera riga, perché il validatore non passa valori incompleti.


## Checklist
- [ x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).