### PR TITLE
fix: PHP short tag

### DIFF
--- a/single-documento_pubblico.php
+++ b/single-documento_pubblico.php
@@ -168,7 +168,7 @@ get_header();
                                                 <?php foreach($tipo_documento as $tipo) { 
                                                     $url = get_term_link($tipo->slug, $tipo->taxonomy);
                                                     ?>
-                                                    <a class="text-decoration-none" href="<?= $url ?>" aria-label="Vai all'archivio <?php echo $tipo->name; ?>" title="Vai all'archivio <?php echo $tipo->name; ?>">
+                                                    <a class="text-decoration-none" href="<?php echo $url; ?>" aria-label="Vai all'archivio <?php echo esc_attr($tipo->name); ?>" title="Vai all'archivio <?php echo esc_attr($tipo->name); ?>">
                                                         <?php echo $tipo->name; ?>
                                                     </a>, 
                                                 <?php }  ?>
@@ -176,26 +176,26 @@ get_header();
                                         </tr>
                                         <tr>
                                             <td><b>Numero e data</b></td>
-                                            <td>n. <?= $numero_protocollo ?> del <?= $data_protocollo ?></td>
+                                            <td>n. <?php echo $numero_protocollo; ?> del <?php echo $data_protocollo; ?></td>
                                         </tr>
                                         <tr>
                                             <td><b>Data di pubblicazione</b></td>
-                                            <td><?= the_date() ?></td>
+                                            <td><?php the_date() ?></td>
                                         </tr>
                                         <tr>
                                             <td><b>Oggetto</b></td>
-                                            <td><?= $descrizione_breve ?></td>
+                                            <td><?php echo $descrizione_breve; ?></td>
                                         </tr>
                                         <?php if ($autori) { ?>
                                             <tr>
                                                 <td><b>Autori</b></td>
-                                                <td><?= $autori ?></td>
+                                                <td><?php echo $autori; ?></td>
                                             </tr>
                                         <?php } ?>
                                         <?php if ($formati) { ?>
                                             <tr>
                                                 <td><b>Formati</b></td>
-                                                <td><?= $formati ?></td>
+                                                <td><?php echo $formati; ?></td>
                                             </tr>
                                         <?php } ?>
                                         <?php if ($licenza) { ?>

--- a/template-parts/home/notizie.php
+++ b/template-parts/home/notizie.php
@@ -81,7 +81,7 @@ $overlapping = "";
                     </div>
                 <?php } ?>
                 <div class="row mb-2">
-                    <div class="card-wrapper px-0 <?= $overlapping ?> card-teaser-wrapper card-teaser-wrapper-equal card-teaser-block-3">
+                    <div class="card-wrapper px-0 <?php echo $overlapping; ?> card-teaser-wrapper card-teaser-wrapper-equal card-teaser-block-3">
                         <?php
                         foreach ($posts as $post) {
                             if ($post) {


### PR DESCRIPTION
Sostituiti short tag php con normali open tag + echo.

## Descrizione

Micro-correzione rapida a un paio di template. Sostituiti <?=... con <?php echo..., secondo [raccomandazioni WP](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#no-shorthand-php-tags).

Insieme alla PR #292, chiude #261 . [resolves #261]

## Checklist
- [ x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
