### PR TITLE
fix: Card luogo come card evento

### DIFF
--- a/template-parts/luogo/card-full.php
+++ b/template-parts/luogo/card-full.php
@@ -8,8 +8,8 @@ $tipi_luogo = get_the_terms($post->ID,'tipi_luogo');
 ?>
 
 <div class="col-lg-6 col-xl-4">
-    <div class="card-wrapper shadow-sm rounded  border border-lightcmp-list-card-img">
-        <div class="card card-img no-after rounded">
+    <div class="card-wrapper shadow-sm rounded border border-light">
+        <div class="card no-after rounded">
             <div class="img-responsive-wrapper">
                 <div class="img-responsive img-responsive-panoramic">
                     <figure class="img-wrapper">
@@ -18,7 +18,7 @@ $tipi_luogo = get_the_terms($post->ID,'tipi_luogo');
                 </div>
             </div>
             <div class="card-body">
-                <div class="category-top ">
+                <div class="category-top">
                     <?php 
                         $count = 1;
                         if ( is_array($tipi_luogo) && count($tipi_luogo) ) {


### PR DESCRIPTION
In luogo/card-full.php, uniformate le classi css con evento/card-full.php, per correggere padding mancante.

## Descrizione
Corregge una discrepanza di layout tra le due card, evidente nella pagina [Vivere il Comune](https://italia.github.io/design-comuni-pagine-statiche/sito/eventi.html), sez. Luoghi.
I due tipi di card dovrebbero avere lo stesso layout.

Prima:
![vivere-il-comune_luoghi-in-evidenza--prima](https://github.com/italia/design-comuni-wordpress-theme/assets/93265448/72fb8f43-84b9-480a-b5cd-7697dbb11a99)
Dopo:
![vivere-il-comune_luoghi-in-evidenza--dopo](https://github.com/italia/design-comuni-wordpress-theme/assets/93265448/ab0fca7e-d4c0-48e9-85fa-2a57cf211acc)


## Checklist
- [x ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).