### PR TITLE
Fix issue #307 e ricerca

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -255,5 +255,5 @@ function console_log ($output, $msg = "log") {
 };
 
 function get_parent_template () {
-	return end(explode('/', get_page_template_slug(wp_get_post_parent_id(get_the_id()))));
+	return basename( get_page_template_slug( wp_get_post_parent_id() ) );
 }

--- a/page-templates/domande-frequenti.php
+++ b/page-templates/domande-frequenti.php
@@ -93,7 +93,9 @@ get_header();
                                     foreach ($faqs as $post) {
                                         ++$i;
                                         get_template_part("template-parts/domanda-frequente/item");
-                                    } ?>
+                                    }
+                                    wp_reset_postdata();
+                                ?>
                             </div>
                         </div>
                     </div>
@@ -110,6 +112,7 @@ get_header();
             </div>     
         </form>
 
+        <?php wp_reset_query(); ?>
         <?php get_template_part("template-parts/common/assistenza-contatti"); ?>
       </main>
 <?php

--- a/search.php
+++ b/search.php
@@ -84,8 +84,8 @@ get_header();
                         <div class="container p-0">
                             <div class="row flex-column-reverse flex-lg-row">
                                 <div class="col-12 pt-3">
+                                <?php if ( have_posts() ) : ?>
                                     <div id="load-more">
-                                        <?php if ( have_posts() ) : ?>
                                             <?php
                                             /* Start the Loop */
                                             while ( have_posts() ) :

--- a/template-parts/documento/tutti-documenti.php
+++ b/template-parts/documento/tutti-documenti.php
@@ -48,12 +48,14 @@ global $the_query, $load_posts, $load_card_type;
         </div>
       </div>
       <div class="row g-4" id="load-more">
-        <?php 
-                    $load_card_type = 'documento';
-                    foreach ($posts as $post) {get_template_part('template-parts/documento/cards-list');
-                }?>
+          <?php
+          $load_card_type = 'documento';
+          foreach ( $posts as $post ) { get_template_part('template-parts/documento/cards-list'); }
+          wp_reset_postdata();
+          ?>
       </div>
       <?php get_template_part("template-parts/search/more-results"); ?>
     </div>
   </form>
 </div>
+<?php wp_reset_query(); ?>

--- a/template-parts/novita/tutte-novita.php
+++ b/template-parts/novita/tutte-novita.php
@@ -60,13 +60,16 @@ global $the_query, $load_posts, $load_card_type;
                 </div>
             </div>
             <div class="row g-4" id="load-more">
-                <?php 
-                    foreach ($posts as $post) {
+                <?php
+                foreach ( $posts as $post ) {
                     $load_card_type = 'notizia';
                     get_template_part('template-parts/novita/cards-list');
-                }?>
+                }
+                wp_reset_postdata();
+                ?>
             </div>
             <?php get_template_part("template-parts/search/more-results"); ?>
         </div>
     </form>
 </div>
+<?php wp_reset_query(); ?>

--- a/template-parts/servizio/tutti-servizi.php
+++ b/template-parts/servizio/tutti-servizi.php
@@ -101,3 +101,4 @@
         </div>
     </form>
 </div>
+<?php wp_reset_query(); ?>


### PR DESCRIPTION
Risolve alcuni problemi con i template delle ricerche.

## Descrizione
FIxes #307 
Il warning php è causato da end() su un array che non può essere passato per riferimento. Fortunatamente l'array non è necessario (il che ci evita un array_key_last o un array_slice, o altre perversioni php per leggere l'ultimo elemento 😁).

Parallelamente, e sempre collegato a search/more-results.php, c'è un altro problema: in alcuni template di pagina viene alterata $wp_query con la ricerca, e all'uscita non viene ripristinata.
Anche $post in alcuni loop secondari [^1] viene settato e non ripristinato all'uscita.
Questo può causare bug non subito evidenti.
Ad es., get_parent_template() richiede che $post sia la pagina "principale", fuori dal loop. [^2]
Invece, senza un wp_reset_postdata o wp_reset_query, riceve in $post l'ultimo elemento dell'iterazione.

Infine, un piccolo bug nell'html + blocco condizionale in search.php.

## Checklist
- [x ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

 [^1]: Intendo loop WP, di post.
 [^2]: Attenzione al template-part more-results.php: usa $the_query ridefinito, e $post originario. Quindi ho separato il reset in due momenti, prima wp_reset_postdata, e solo dopo, wp_reset_query.