### PR TITLE
fix: deprecation notices in CMB2

### DIFF
--- a/inc/lib/CMB2-field-Leaflet-Geocoder/cmb-field-leaflet-map.php
+++ b/inc/lib/CMB2-field-Leaflet-Geocoder/cmb-field-leaflet-map.php
@@ -137,7 +137,7 @@ class CMB2_Field_Leaflet {
      *
      * @internal param array $args
      */
-    protected function render_input( $field_name = '', CMB2_Field $field, $field_escaped_value, CMB2_Types $field_type_object ) {
+    protected function render_input( $field_name, CMB2_Field $field, $field_escaped_value, CMB2_Types $field_type_object ) {
         $attrs = $field_type_object->concat_attrs( [
             'id'    => "{$field->args( 'id' )}_{$field_name}",
             'type'  => 'hidden',

--- a/inc/lib/cmb-field-select2-master/cmb-field-select2.php
+++ b/inc/lib/cmb-field-select2-master/cmb-field-select2.php
@@ -80,7 +80,8 @@ class PW_CMB2_Field_Select2 {
 	 * Return the list of options, with selected options at the top preserving their order. This also handles the
 	 * removal of selected options which no longer exist in the options array.
 	 */
-	public function get_pw_multiselect_options( $field_escaped_value = array(), $field_type_object ) {
+	public function get_pw_multiselect_options( $field_escaped_value, $field_type_object ) {
+		if ( empty($field_escaped_value) ) $field_escaped_value = array();
 		$options = (array) $field_type_object->field->options();
 
 		// If we have selected items, we need to preserve their order


### PR DESCRIPTION
Notice php causati da argomenti opzionali che ne precedono altri obbligatori, in metodi di classi CMB2.

## Descrizione
Fixes #315 

NB: i notice [^1] sono emessi [da php >= 8.0](https://www.php.net/manual/en/migration80.deprecated.php#migration80.deprecated.core).

[^1]: Questi warning sono verosimilmente quello che si intendeva correggere [qui](https://github.com/italia/design-comuni-wordpress-theme/pull/188/commits/59ee05307265815cb4906a332249fbc96afc6891). Il che vedo che ha poi portato ai problemi di #198, e infine a un revert, ma solo perché era stato cambiato l'ordine dei parametri nella signature di funzione. In realtà basta togliere il default, lasciandoli al loro posto.

## Checklist
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).