### PR TITLE
fix: "Carica altri risultati": tolte WP_Query da config. script

### DIFF
--- a/inc/load_more.php
+++ b/inc/load_more.php
@@ -8,9 +8,6 @@ function load_more_script() {
     wp_enqueue_script( 'dci-load_more', get_template_directory_uri() . '/assets/js/load_more.js', array('jquery'), null, true );
     $variables = array(
         'ajaxurl' => admin_url( 'admin-ajax.php' ),
-        'wp_query' => json_encode( $wp_query ), 
-        'the_query' => json_encode( $the_query ), 
-        'wp_the_query' => json_encode( $wp_the_query ), 
         'posts' => json_encode( $wp_query->query_vars ), 
 		'current_page' => get_query_var( 'paged' ) ? get_query_var('paged') : 1,
 		'max_page' => $wp_query->max_num_pages,


### PR DESCRIPTION
Le WP_Query passate nella configurazione del javascript per le ricerche ajax sono inutili e pericolose: tolte.

## Descrizione
Fixes #324 

## Checklist
- [x ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).