### PR TITLE
feat: Riordino inclusione stylesheet tema

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -158,8 +158,6 @@ function dci_scripts() {
 
     //wp_deregister_script('jquery');
 
-	wp_enqueue_style( 'dci-wp-style', get_template_directory_uri()."/style.css" );
-	wp_enqueue_style( 'dci-font', get_template_directory_uri() . '/assets/css/fonts.css');
 	//load Bootstrap Italia latest css if exists in node_modules
     if (file_exists(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'node_modules/bootstrap-italia/dist/css/bootstrap-italia-comuni.min.css')) {
         wp_enqueue_style( 'dci-boostrap-italia-min', get_template_directory_uri() . '/node_modules/bootstrap-italia/dist/css/bootstrap-italia-comuni.min.css');
@@ -167,7 +165,11 @@ function dci_scripts() {
     else {
         wp_enqueue_style( 'dci-boostrap-italia-min', get_template_directory_uri() . '/assets/css/bootstrap-italia.min.css');
     }
-	wp_enqueue_style( 'dci-comuni', get_template_directory_uri() . '/assets/css/comuni.css');
+    wp_enqueue_style( 'dci-comuni', get_template_directory_uri() . '/assets/css/comuni.css', array('dci-boostrap-italia-min'));
+
+    wp_enqueue_style( 'dci-font', get_template_directory_uri() . '/assets/css/fonts.css', array('dci-comuni'));
+    wp_enqueue_style( 'dci-wp-style', get_template_directory_uri()."/style.css", array('dci-comuni'));
+
 
 	wp_enqueue_script( 'dci-modernizr', get_template_directory_uri() . '/assets/js/modernizr.custom.js');
 


### PR DESCRIPTION
I css del tema è bene che siano caricati in ordine di specificità, dal più generico.

## Descrizione
Riordinata l'inclusione, e specificate le dipendenze reciproche fra stylesheet.
Prima la libreria Bootstrap, poi il modulo Comuni, infine il css del tema vero e proprio.
Questo facilita le modifiche, e riduce il css necessario alle correzioni. [^1]

Specialmente utile nel caso di un child theme, il cui stylesheet di solito è accodato _dopo_ gli altri css "base", e li estende o corregge dove opportuno.

[^1]: Con chiare dipendenze, è più facile posizionare gli stylesheet. Altrimenti, se lo stylesheet child non è accodato ma sta prima degli altri che deve sovrascrivere, facilmente si è costretti ad aumentare la specificità delle regole da sovrapporre, per dargli più peso. Il che è scomodo, crea disordine e più codice, e a volte ha anche effetti collaterali. Se il css sta in fondo alla cascade, si sovrappone naturalmente anche con pari peso.

## Checklist
- [x ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).