### PR TITLE
Piccolo bug layout sez. Hero in dett. Argomento

### DIFF
--- a/archive-argomento.php
+++ b/archive-argomento.php
@@ -28,9 +28,9 @@ get_header();
       <?php } ?>
       <div class="container">
         <div class="row">
-          <div class="col-12 px-0 px-lg-2 drop-shadow">
+          <div class="col-12 px-0 px-lg-2">
             <div
-              class="it-hero-card it-hero-bottom-overlapping rounded hero-p pb-lg-80"
+              class="it-hero-card it-hero-bottom-overlapping rounded hero-p pb-lg-80 drop-shadow"
             >
   
                 <div class="row justify-content-center">

--- a/archive-argomento.php
+++ b/archive-argomento.php
@@ -30,7 +30,7 @@ get_header();
         <div class="row">
           <div class="col-12 px-0 px-lg-2">
             <div
-              class="it-hero-card it-hero-bottom-overlapping rounded hero-p pb-lg-80 drop-shadow"
+              class="it-hero-card it-hero-bottom-overlapping rounded hero-p pb-lg-80 drop-shadow <?php echo ($img? '' : 'mt-0'); ?>"
             >
   
                 <div class="row justify-content-center">


### PR DESCRIPTION
## Descrizione
Quickfix per un bug di layout sulla sez. hero del template Argomento.
L'ombra della sezione Hero non è applicata alla scheda bianca, ma al suo contenitore, ed è quindi disallineata, e troncata in basso. Il difetto è più evidente quando l'immagine manca, ma c'è sempre. [^1]
[^1]: In realtà, questo punto è più un bug del [layout di _pagine-statiche_](https://github.com/italia/design-comuni-pagine-statiche/blob/main/src/pages/sito/argomento.hbs), e andrebbe corretto anche là.

-> Soluzione: spostata l'ombra sul blocco interno.

Inoltre, quando manca l'immagine, [^2] non ha più senso il layout con il box bianco circondato dalla foto, e perlomeno va tolto il margine che stacca il box dal menù in alto. Rimane sempre la "sovrapposizione" dell'hero con la sezione sotto, che forse senza l'immagine non è più motivata, ma non si può correggere senza cambiare diverse parti. [^3]

-> Soluzione: tolto il margine in alto.

[^2]: La bozza statica non considera una variante senza immagine. Tuttavia, è facile che non tutti gli Argomenti (e non tutti i Comuni) avranno un'immagine da usare in testata: quindi ha senso tenerla facoltativa.
[^3]: Questa proposta è solo un quickfix. Una soluzione più approfondita dovrebbe forse coinvolgere anche Bootstrap Italia, oltre che _pagine-statiche_.  
In particolare, vincolare tra loro l'html del modulo Hero e quello del seguente Notizie, non è una buona idea, i 2 moduli non sono indipendenti. Notizie non dovrebbe "sapere" di stare dopo un Hero che "si abbassa".
Ora, la spaziatura verso il basso di Notizie per far posto allo scostamento del blocco sopra, è realizzata in parte come margine del titolo di Notizie, e in parte come padding. Meglio se fosse riunita in un punto solo. Meglio ancora se fosse la classe `"it-hero-bottom-overlapping"` a occuparsi sia del proprio scostamento, sia di ricavarne lo spazio dal blocco seguente. E a questo punto, la classe sarebbe da riscrivere nel css, e applicare come `div.it-hero-wrapper.it-hero-bottom-overlapping`, in modo da consentire una regola su `it-hero-wrapper.it-hero-bottom-overlapping + section`, senza bisogno di alterare con classi bootstrap l'html del modulo che segue.

![difetto-ombra-hero-argomento](https://github.com/italia/design-comuni-wordpress-theme/assets/93265448/2257b38c-a590-43e9-807e-4af76143a40b)
_(ombra accentuata per chiarezza)_

![hero-argomento_2_r](https://github.com/italia/design-comuni-wordpress-theme/assets/93265448/f777567d-4599-46a2-b5ea-b0c1b0811edc)


## Checklist
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).