### PR TITLE
Servizio: correzioni json ld

### DIFF
--- a/single-servizio.php
+++ b/single-servizio.php
@@ -65,26 +65,34 @@ get_header();
                 return trim(strip_tags($text));
             };
             ?>
-            <script type="application/ld+json" data-element="metatag">{
+            <script type="application/ld+json" data-element="metatag">
+                {
+                    "@context": "http://schema.org",
+                    "@type": "GovernmentService",
                     "name": <?php echo json_encode($post->post_title); ?>,
                     "serviceType": <?php echo json_encode($categoria_servizio); ?>,
                     "serviceOperator": {
+                        "@type": "GovernmentOrganization",
                         "name": <?php echo json_encode($ipa); ?>
                     },
                     <?php if ( !empty($copertura_geografica) ) : ?>
                     "areaServed": {
+                        "@type": "AdministrativeArea",
                         "name": "<?php echo convertToPlain($copertura_geografica); ?>"
                     },
                     <?php endif; ?>
                     "audience": {
+                        "@type": "Audience",
                         "audienceType": "<?php echo convertToPlain($destinatari); ?>"
                     },
                     "availableChannel": {
+                        "@type": "ServiceChannel",
+                        "name": "Dove rivolgersi"
                         <?php if ( !empty($canale_digitale_link) ) : ?>
-                        "serviceUrl": <?php echo json_encode($canale_digitale_link) . (!empty($ufficio) ? ',' : ''); ?>
+                        ,"serviceUrl": <?php echo json_encode($canale_digitale_link); ?>
                         <?php endif; ?>
                         <?php if ( !empty($ufficio) ) : ?>
-                        "serviceLocation": {
+                        ,"serviceLocation": {
                             "name": <?php echo json_encode($ufficio->post_title); ?>,
                             "address": {
                                 "streetAddress": <?php echo json_encode($indirizzo); ?>,
@@ -96,7 +104,8 @@ get_header();
                         }
                         <?php endif; ?>
                     }
-            }</script>
+                }
+            </script>
             <div class="container" id="main-container">
                 <div class="row justify-content-center">
                     <div class="col-12 col-lg-10">

--- a/single-servizio.php
+++ b/single-servizio.php
@@ -66,10 +66,10 @@ get_header();
             };
             ?>
             <script type="application/ld+json" data-element="metatag">{
-                    "name": "<?php echo esc_js($post->post_title); ?>",
-                    "serviceType": "<?php echo esc_js($categoria_servizio); ?>",
+                    "name": <?php echo json_encode($post->post_title); ?>,
+                    "serviceType": <?php echo json_encode($categoria_servizio); ?>,
                     "serviceOperator": {
-                        "name": "<?php echo esc_js($ipa); ?>"
+                        "name": <?php echo json_encode($ipa); ?>
                     },
                     <?php if ( !empty($copertura_geografica) ) : ?>
                     "areaServed": {
@@ -81,16 +81,16 @@ get_header();
                     },
                     "availableChannel": {
                         <?php if ( !empty($canale_digitale_link) ) : ?>
-                        "serviceUrl": "<?php echo esc_js($canale_digitale_link); ?>",
+                        "serviceUrl": <?php echo json_encode($canale_digitale_link) . (!empty($ufficio) ? ',' : ''); ?>
                         <?php endif; ?>
                         <?php if ( !empty($ufficio) ) : ?>
                         "serviceLocation": {
-                            "name": "<?php echo esc_js($ufficio->post_title); ?>",
+                            "name": <?php echo json_encode($ufficio->post_title); ?>,
                             "address": {
-                                "streetAddress": "<?php echo esc_js($indirizzo); ?>",
-                                "postalCode": "<?php echo esc_js($cap); ?>"
+                                "streetAddress": <?php echo json_encode($indirizzo); ?>,
+                                "postalCode": <?php echo json_encode((string)$cap); ?>
                                 <?php if ( !empty($quartiere) ) : ?>,
-                                "addressLocality": "<?php echo esc_js($quartiere); ?>"
+                                "addressLocality": <?php echo json_encode($quartiere); ?>
                                 <?php endif; ?>
                             }
                         }

--- a/single-servizio.php
+++ b/single-servizio.php
@@ -115,7 +115,7 @@ get_header();
                                     </h1>
                                     <ul class="d-flex flex-wrap gap-1 my-3">
                                         <li>
-                                            <div class="chip chip-simple text-button" data-element="service-status">
+                                            <div class="chip chip-simple <?php echo $stato == 'true'? 'chip-success' : 'chip-danger'; ?>" data-element="service-status">
                                                 <span class="chip-label">
                                                 <?php if ( $stato == 'true' ) {
                                                     echo 'Servizio attivo';


### PR DESCRIPTION
## Descrizione
- I valori nel JSON-LD della scheda Servizio è bene che siano encodati con json_encode(), non con esc_js(), perchè nel caso di presenza di apostrofi o virgolette si potrebbe ottenere json invalido. [^1]

- Le specifiche per il JSON-LD vengono indicate sia [nella docum. dell'app valutazione, §5.21](https://docs.italia.it/italia/designers-italia/app-valutazione-modelli-docs/it/versione-attuale/requisiti-e-modalita-verifica-comuni.html#raccomandazione-r-si-1-1-metatag), sia in quella [generale del modello Comuni §2.1.10.1](https://docs.italia.it/italia/designers-italia/design-comuni-docs/it/versione-corrente/modello-sito-comunale/architettura-informazione.html#dati-strutturati-e-interoperabilita).  
Nella doc. generale il template è un po' più dettagliato e completo: usato quello schema.

- ~~Nell'esempio di template citato, viene chiarito che addressLocality non contiene il quartiere, ma il Comune.  
Qui c'è un problema, perché **nei Luoghi, il campo Comune manca**. Viene forse dato per scontato che tutti i servizi siano sempre erogati all'interno del territorio comunale del sito? Comunque sia, in attesa di un fix mirato sui luoghi, è probabilmente sensato riutilizzare il nome IPA anche nell'indirizzo. **Non è una soluzione definitiva però**, perché certamente non è nel formato corretto per un indirizzo postale.~~

- ~~Stabilito un default per il nome IPA (visto che è necessario ed è probabilmente sempre lo stesso per tutti o quasi i servizi). Se non viene compilato  sulla scheda servizio, un default plausibile è l'opzione "Nome del Comune* della Configurazione sito.~~

- Infine (non correlato al json), il tag "attivo/non attivo" deve avere un colore diverso in base allo stato di attivazione del servizio.

#### Edit:
Ho tolto dalla PR la parte di addressLocality, su cui ci sono altre proposte attualmente in discussione. E soprattutto perché sarebbe al più una mezza soluzione a un problema più complesso.

## Checklist
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

[^1]: _disclosure_: questo bug, temo proprio di averlo introdotto io... In prospettiva, sia per sicurezza che per praticità, si può valutare di affidare la compilazione dell'intero json a json_encode(), passandole un oggettto, invece che usarla solo per l'encoding dei valori.
