### PR TITLE
fix: load more order

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -9,6 +9,8 @@
  * @package Design_Comuni_Italia
  */
 ?>
+<?php get_template_part("template-parts/common/search-modal"); ?>
+
 <footer class="it-footer" id="footer">
     <div class="it-footer-main">
         <div class="container">

--- a/header.php
+++ b/header.php
@@ -189,7 +189,6 @@ $current_group = dci_get_current_group();
 
 </header>
 
-<?php get_template_part("template-parts/common/search-modal"); ?>
 <?php
 if(!is_user_logged_in())
     get_template_part("template-parts/common/access-modal");

--- a/inc/load_more.php
+++ b/inc/load_more.php
@@ -39,8 +39,8 @@ function load_more(){
         's' => $_POST['search'],
         'posts_per_page' => $_POST['post_count'] + $_POST['load_posts'],
         'post_type'      => $post_types,
-        'orderby'        => 'post_title',
-        'order'          => 'ASC'
+        'orderby'        => 'date',
+        'order'          => 'DESC'
     );
 
 	if ( isset($url_query_params["post_terms"]) ) {

--- a/inc/load_more.php
+++ b/inc/load_more.php
@@ -42,6 +42,16 @@ function load_more(){
         'orderby'        => 'date',
         'order'          => 'DESC'
     );
+	
+	if ( $post_types != "notizia" ) {
+		$args = array(
+			's' => $_POST['search'],
+	    'posts_per_page' => $_POST['post_count'] + $_POST['load_posts'],
+	    'post_type'      => $post_types,
+			'orderby' => 'post_title',
+			'order'   => 'ASC'
+		);
+	}
 
 	if ( isset($url_query_params["post_terms"]) ) {
 		$taxquery = array(


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Fixed the `load_more` function adding different ordering upon different post types.

Default arguments set a decrescent order by date. 

Ascendent order by `post_title` is kept for all post types except 'notizia'.

Resolves #17 #136 #160 #163  #192 #332 #380 #383

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->