### PR TITLE
Feat: aggiunto il colore arancione nella pagina Avvisi in Home

### DIFF
--- a/inc/admin-css/style-admin.css
+++ b/inc/admin-css/style-admin.css
@@ -209,6 +209,9 @@
 .cmb2-options-box .radio-color.yellow {
     background-color: #FFCC00;
 }
+.cmb2-options-box .radio-color.orange {
+    background-color: #FF8000;
+}
 
 #spinner-overlayer {
     position: fixed;

--- a/inc/admin/options/pagina_avvisi.php
+++ b/inc/admin/options/pagina_avvisi.php
@@ -50,6 +50,7 @@ function dci_register_pagina_avvisi_options(){
         'type'    => 'radio_inline',
         'options' => array(
             'red'   => __( '<span class="radio-color red"></span>Rosso', 'design_comuni_italia' ),
+            'orange'   => __( '<span class="radio-color orange"></span>Arancione', 'design_comuni_italia' ),
             'yellow' => __( '<span class="radio-color yellow"></span>Giallo', 'design_comuni_italia' ),
             'green'     => __( '<span class="radio-color green"></span>Verde', 'design_comuni_italia' ),
             'blue'     => __( '<span class="radio-color blue"></span>Blu', 'design_comuni_italia' ),

--- a/style.css
+++ b/style.css
@@ -929,3 +929,9 @@ svg.leaflet-image-layer.leaflet-interactive path {
   color: #333 !important;
   fill: #333 !important;
 }
+.home-message.orange,
+.home-message.orange .msg svg {
+  background-color: #FF8000;
+  color: #333 !important;
+  fill: #333 !important;
+}


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->
Aggiunto un nuovo colore arancione tra le opzioni per la sezione "Avvisi in Home".

## Descrizione
Fixes #382 
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->