### PR TITLE
Third party breadcrumb filter

### DIFF
--- a/inc/breadcrumb.php
+++ b/inc/breadcrumb.php
@@ -352,6 +352,12 @@ class Breadcrumb_Trail {
                 }
             }
 
+		$custom_breadcrumbs = apply_filters( 'dci_get_breadcrumb_items', $this->items );
+		if ( !empty( $custom_breadcrumbs ) ) {
+			$this->items = $custom_breadcrumbs;
+			return;
+		}
+
             if ( is_singular() ) {
 
 				if (get_post_type() == 'servizio') {


### PR DESCRIPTION


<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Aggiunta di un filtro per consentire a funzioni e plugin terzi di variare il risultato dei breadcrumb, ad esempio aggiungendo prefissi o sezioni in alcuni livelli.

Esempio di utilizzo:
```
add_filter( 'dci_get_breadcrumb_items',  'my_test_function', 10, 2 );

function my_test_function( $items ) {     
 $items[] =  "<a href='URL'>TITLE</a>";
 return $items;
}
```

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->