### PR TITLE
Template archivio Tipi Notizia

### DIFF
--- a/inc/admin/tassonomie/tassonomia_tipi_notizia.php
+++ b/inc/admin/tassonomie/tassonomia_tipi_notizia.php
@@ -21,11 +21,11 @@ function dci_register_taxonomy_tipi_notizia() {
     $args = array(
         'hierarchical'      => true,
         'labels'            => $labels,
-        'public'            => false, //enable to get term archive page
+        'public'            => true, //enable to get term archive page
         'show_ui'           => true,
         'show_admin_column' => true,
         'query_var'         => true,
-        'has_archive'           => false,    //archive page
+        'has_archive'       => true, //archive page
         //'rewrite'           => array( 'slug' => 'novita' ),
         'capabilities'      => array(
             'manage_terms'  => 'manage_tipi_notizia',

--- a/taxonomy-tipi_notizia.php
+++ b/taxonomy-tipi_notizia.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Archivi tassonomia Tipi Notizia
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#custom-taxonomies
+ * @link https://italia.github.io/design-comuni-pagine-statiche/sito/lista-risorse.html
+ *
+ * @package Design_Comuni_Italia
+ */
+
+get_header();
+?>
+
+<main>
+	<div class="container" id="main-container">
+		<div class="row justify-content-center">
+			<div class="col-12 col-lg-10">
+				<?php get_template_part("template-parts/common/breadcrumb"); ?>
+			</div>
+		</div>
+	</div>
+
+	<div class="container">
+		<div class="row justify-content-center row-shadow">
+			<div class="col-12 col-lg-10">
+				<div class="cmp-hero">
+					<section class="it-hero-wrapper bg-white align-items-start">
+						<div class="it-hero-text-wrapper pt-0 ps-0 pb-4 pb-lg-60">
+							<h1 class="text-black" data-element="page-name"><?php echo single_term_title( '', false ); ?></h1>
+							<?php the_archive_description('<div class="hero-text"> <p>','</p> </div>'); ?>
+						</div>
+					</section>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="bg-grey-card py-5">
+		<div class="container">
+
+			<?php if ( have_posts() ) : ?>
+			<div class="row g-4">
+				<?php while ( have_posts() ) : the_post(); ?>
+
+					<?php get_template_part( 'template-parts/' . 'novita/cards-list' ); ?>
+
+				<?php endwhile; ?>
+			</div>
+
+			<div class="row my-4">
+				<nav class="pagination-wrapper justify-content-center col-12" aria-label="Navigazione pagine">
+					<?php echo dci_bootstrap_pagination(); ?>
+				</nav>
+			</div>
+			<?php else : ?>
+				<?php get_template_part( 'template-parts/content', 'none' ); ?>
+			<?php endif; ?>
+
+		</div>
+	</div>
+
+	<?php get_template_part("template-parts/common/valuta-servizio"); ?>
+	<?php get_template_part("template-parts/common/assistenza-contatti"); ?>
+
+</main>
+
+<?php
+get_footer();


### PR DESCRIPTION
## Descrizione

Template semplificato per la tassonomia `tipi_notizia` (_Notizie_, _Comunicati_, _Avvisi_).

Lista semplice paginata, secondo il layout della sez. "Esplora" del template [Lista risorse](https://italia.github.io/design-comuni-pagine-statiche/sito/lista-risorse.html), ma senza campo ricerca.

---
![tipi_notizia_notizie](https://github.com/italia/design-comuni-wordpress-theme/assets/93265448/25265282-5c91-42e9-8667-4698bfba8826)



## Checklist
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).