### PR TITLE
Fix pagina tipologia documento, relativo alla issue #404

### DIFF
--- a/inc/admin/tassonomie/tassonomia_tipi_doc_albo_pretorio.php
+++ b/inc/admin/tassonomie/tassonomia_tipi_doc_albo_pretorio.php
@@ -25,7 +25,7 @@ function dci_register_taxonomy_tipi_doc_albo_pretorio() {
         'show_ui'           => true,
         'show_admin_column' => true,
         'query_var'         => true,
-        'has_archive'           => false,    //archive page
+        'has_archive'           => true,    //archive page
         //'rewrite'           => array( 'slug' => 'tipo-doc-albo-pretorio' ),
         'capabilities'      => array(
             'manage_terms'  => 'manage_tipi_doc_albo_pretorio',

--- a/inc/admin/tassonomie/tassonomia_tipi_documento.php
+++ b/inc/admin/tassonomie/tassonomia_tipi_documento.php
@@ -21,11 +21,11 @@ function dci_register_taxonomy_tipi_documento() {
     $args = array(
         'hierarchical'      => true,
         'labels'            => $labels,
-        'public'            => false, //enable to get term archive page
+        'public'            => true, //enable to get term archive page
         'show_ui'           => true,
         'show_admin_column' => true,
         'query_var'         => true,
-        'has_archive'           => false,    //archive page
+        'has_archive'           => true,    //archive page
         //'rewrite'           => array( 'slug' => 'tipo-documento' ),
         'capabilities'      => array(
             'manage_terms'  => 'manage_tipi_documento',

--- a/taxonomy-tipi_documento.php
+++ b/taxonomy-tipi_documento.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Archivio tassonomia Tipi Documento
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#custom-taxonomies
+ * @link https://italia.github.io/design-comuni-pagine-statiche/sito/lista-risorse.html
+ *
+ * @package Design_Comuni_Italia
+ */
+
+get_header();
+?>
+
+<main>
+	<div class="container" id="main-container">
+		<div class="row justify-content-center">
+			<div class="col-12 col-lg-10">
+				<?php get_template_part("template-parts/common/breadcrumb"); ?>
+			</div>
+		</div>
+	</div>
+
+	<div class="container">
+		<div class="row justify-content-center row-shadow">
+			<div class="col-12 col-lg-10">
+				<div class="cmp-hero">
+					<section class="it-hero-wrapper bg-white align-items-start">
+						<div class="it-hero-text-wrapper pt-0 ps-0 pb-4 pb-lg-60">
+							<h1 class="text-black" data-element="page-name"><?php echo single_term_title( '', false ); ?></h1>
+							<?php the_archive_description('<div class="hero-text"> <p>','</p> </div>'); ?>
+						</div>
+					</section>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div class="bg-grey-card py-5">
+		<div class="container">
+
+			<?php if ( have_posts() ) : ?>
+			<div class="row g-4">
+				<?php while ( have_posts() ) : the_post(); ?>
+
+					<?php get_template_part( 'template-parts/' . 'documento/cards-list' ); ?>
+
+				<?php endwhile; ?>
+			</div>
+
+			<div class="row my-4">
+				<nav class="pagination-wrapper justify-content-center col-12" aria-label="Navigazione pagine">
+					<?php echo dci_bootstrap_pagination(); ?>
+				</nav>
+			</div>
+			<?php else : ?>
+				<?php get_template_part( 'template-parts/content', 'none' ); ?>
+			<?php endif; ?>
+
+		</div>
+	</div>
+
+	<?php get_template_part("template-parts/common/valuta-servizio"); ?>
+	<?php get_template_part("template-parts/common/assistenza-contatti"); ?>
+
+</main>
+
+<?php
+get_footer();


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Ho aggiunto il nuovo template sul tipo_documento, feature già presente per la tipologia notizie 
Esempio: https://www.comune.ali.me.it/tipi_documento/documento-funzionamento-interno/
Un esempio per lo slug: https://comune.nomecomune.me.it/tipi_documento/documento-di-programmazione-e-rendicontazione/

Ho usato il file taxonomy-tipi_notizia.php come esempio per poter creare il template e ho abilitato l'archivio nel backend del template.


<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->