### PR TITLE
Template "tutti i luoghi"

### DIFF
--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -29,6 +29,8 @@ function dci_register_main_options_metabox() {
     dci_register_pagina_documenti_options();
 
     dci_register_pagina_vivi_options();
+	
+	dci_register_pagina_luoghi_options();
 
     dci_register_pagina_argomenti_options();
 

--- a/inc/admin/options/pagina_luoghi.php
+++ b/inc/admin/options/pagina_luoghi.php
@@ -1,0 +1,65 @@
+<?php
+
+function dci_register_pagina_luoghi_options(){
+    $prefix = '';
+
+    /**
+     * Opzioni Luoghi
+     */
+    $args = array(
+        'id'           => 'dci_options_luoghi',
+        'title'        => esc_html__( 'Luoghi', 'design_comuni_italia' ),
+        'object_types' => array( 'options-page' ),
+        'option_key'   => 'luoghi',
+        'tab_title'    => __('Luoghi', "design_comuni_italia"),
+        'parent_slug'  => 'dci_options',
+        'tab_group'    => 'dci_options',
+        'capability'    => 'manage_options',
+    );
+
+    // 'tab_group' property is supported in > 2.4.0.
+    if ( version_compare( CMB2_VERSION, '2.4.0' ) ) {
+        $args['display_cb'] = 'dci_options_display_with_tabs';
+    }
+    $luoghi_options = new_cmb2_box( $args );
+    $luoghi_options->add_field( array(
+        'id' => $prefix . 'luoghi_options',
+        'name'        => __( 'Luoghi', 'design_comuni_italia' ),
+        'desc' => __( 'Configurazione della pagina Luoghi' , 'design_comuni_italia' ),
+        'type' => 'title',
+    ) );
+    $luoghi_options->add_field( array(
+        'id' => $prefix . 'immagine',
+        'name'        => __( 'Immagine', 'design_comuni_italia' ),
+        'desc' => __( 'Immagine/ banner (in alto nella pagina)' , 'design_comuni_italia' ),
+        'type' => 'file',
+        'query_args' => array( 'type' => 'image' ),
+    ) );
+    $luoghi_options->add_field( array(
+        'id' => $prefix . 'didascalia',
+        'name'        => __( 'Didascalia', 'design_comuni_italia' ),
+        //'desc' => __( 'didascalia.' , 'design_comuni_italia' ),
+        'type' => 'text',
+    ) );
+    $luoghi_options->add_field(array(
+            'name' => __('Luoghi in evidenza', 'design_comuni_italia'),
+            'desc' => __('Seleziona i luoghi in evidenza. NB: Selezionane 3 o multipli di 3 per evitare buchi nell\'impaginazione.  ', 'design_comuni_italia'),
+            'id' => $prefix . 'luoghi_evidenziati',
+            'type'    => 'custom_attached_posts',
+            'column'  => true, // Output in the admin post-listing as a custom column. https://github.com/CMB2/CMB2/wiki/Field-Parameters#column
+            'options' => array(
+                'show_thumbnails' => false, // Show thumbnails on the left
+                'filter_boxes'    => true, // Show a text box for filtering the results
+                'query_args'      => array(
+                    'posts_per_page' => -1,
+                    'post_type'      => array(
+                        'luogo'
+                    )
+                ), // override the get_posts args
+            ),
+            'attributes' => array(
+                'data-max-items' => 6, //change the value here to how many posts may be attached.
+            )
+        )
+    );
+}

--- a/inc/admin/options/pagina_luoghi.php
+++ b/inc/admin/options/pagina_luoghi.php
@@ -31,7 +31,7 @@ function dci_register_pagina_luoghi_options(){
     $luoghi_options->add_field( array(
         'id' => $prefix . 'immagine',
         'name'        => __( 'Immagine', 'design_comuni_italia' ),
-        'desc' => __( 'Immagine/ banner (in alto nella pagina)' , 'design_comuni_italia' ),
+        'desc' => __( 'Immagine di copertina della pagina (opzionale)' , 'design_comuni_italia' ),
         'type' => 'file',
         'query_args' => array( 'type' => 'image' ),
     ) );

--- a/inc/comuni_pagine.json
+++ b/inc/comuni_pagine.json
@@ -105,7 +105,15 @@
       "slug": "domande-frequenti",
       "description": "Elenco di risposte alle domande più frequenti raccolte dalle richieste di assistenza dei cittadini.",
       "template_name": "domande-frequenti",
-      "children": {}
+      "children": {
+		  "Tutti i luoghi": {
+          "title": "I luoghi",
+          "slug": "luoghi",
+          "description": "Tutti i luoghi d’interesse per scoprire il territorio comunale.",
+          "template_name": "luoghi",
+          "children": {}
+		  
+	  }
     }
   }
 }

--- a/inc/load_more.php
+++ b/inc/load_more.php
@@ -39,6 +39,7 @@ function load_more(){
         's' => $_POST['search'],
         'posts_per_page' => $_POST['post_count'] + $_POST['load_posts'],
         'post_type'      => $post_types,
+		'post_status'    => 'publish',
         'orderby'        => 'date',
         'order'          => 'DESC'
     );
@@ -46,8 +47,9 @@ function load_more(){
 	if ( $post_types != "notizia" ) {
 		$args = array(
 			's' => $_POST['search'],
-	    'posts_per_page' => $_POST['post_count'] + $_POST['load_posts'],
-	    'post_type'      => $post_types,
+	    	'posts_per_page' => $_POST['post_count'] + $_POST['load_posts'],
+	    	'post_type'      => $post_types,
+			'post_status'    => 'publish',
 			'orderby' => 'post_title',
 			'order'   => 'ASC'
 		);
@@ -100,7 +102,11 @@ function load_more(){
 		}	
 		if ($load_card_type == "domanda-frequente"){
 			$out .= load_template_part("template-parts/domanda-frequente/item");  
+		}
+		if ($load_card_type == "luogo"){
+			$out .= load_template_part("template-parts/luogo/card-full");  
 		}	
+ 
  
 		endwhile;
  

--- a/page-templates/luoghi.php
+++ b/page-templates/luoghi.php
@@ -1,0 +1,64 @@
+<?php
+/* Template Name: I Luoghi
+ *
+ * I luoghi template file
+ *
+ * @package Design_Comuni_Italia
+ */
+global $post;
+get_header();
+
+?>
+	<main>
+		<?php
+		while ( have_posts() ) :
+			the_post();
+			
+			$img = dci_get_option('immagine', 'luoghi');
+			$didascalia = dci_get_option('didascalia', 'luoghi');
+		
+			$args = array(
+				'posts_per_page' => -1,
+				'post_type' => 'luogo',
+				'post_status'    => 'publish'
+			);
+			$schede_luoghi = get_posts($args);
+
+		?>
+		<?php 
+			$with_shadow = true;
+			get_template_part("template-parts/hero/hero"); 
+		?>
+			
+		<?php if( $img ) { ?>
+			<section class="hero-img mb-20 mb-lg-50">
+				<section class="it-hero-wrapper it-hero-small-size cmp-hero-img-small">
+					<div class="img-responsive-wrapper">
+						<div class="img-responsive">
+							<div class="img-wrapper">
+								<?php dci_get_img($img); ?>
+							</div>
+						</div>
+					</div>
+				</section>
+				<p class="title-xsmall cmp-hero-img-small__description">
+					<?php echo $didascalia; ?>
+				</p>
+			</section>
+		<?php } ?>
+		
+		<?php get_template_part("template-parts/luogo/evidenza"); ?>
+		<?php get_template_part("template-parts/luogo/tutti-luoghi"); ?>
+		<?php get_template_part("template-parts/common/valuta-servizio"); ?>
+		<?php get_template_part("template-parts/common/assistenza-contatti"); ?>
+							
+		<?php 
+			endwhile; // End of the loop.
+		?>
+	</main>
+
+<?php
+get_footer();
+
+
+

--- a/template-parts/luogo/evidenza.php
+++ b/template-parts/luogo/evidenza.php
@@ -1,0 +1,24 @@
+<?php
+    global $post, $posts;
+	// Per selezionare i contenuti in evidenza tramite flag
+	// $luoghi = dci_get_highlighted_posts(['luogo'], 6);
+
+	//Per selezionare i contenuti in evidenza tramite configurazione
+	$luoghi = dci_get_option('luoghi_evidenziati','luoghi');
+
+	$url_luoghi = get_permalink( get_page_by_title('Luoghi') );
+	if (is_array($luoghi) && count($luoghi)) {
+?>
+
+<div class="container py-5">
+	<h2 class="title-xxlarge mb-4">Luoghi in evidenza</h2>
+	<div class="row g-4">
+		<?php
+			foreach ($luoghi as $luogo_id) {
+				$post = get_post($luogo_id);
+				get_template_part("template-parts/luogo/card-full");
+			}
+		?>
+	</div>
+</div>
+<?php } ?>

--- a/template-parts/luogo/tutti-luoghi.php
+++ b/template-parts/luogo/tutti-luoghi.php
@@ -1,0 +1,66 @@
+<?php
+global $the_query, $load_posts, $load_card_type;
+
+    $max_posts = isset($_GET['max_posts']) ? $_GET['max_posts'] : 3;
+    $load_posts = 3;
+    $query = isset($_GET['search']) ? dci_removeslashes($_GET['search']) : null;
+    $args = array(
+        's' => $query,
+        'posts_per_page' => $max_posts,
+        'post_type'      => 'luogo',
+		'post_status'    => 'publish',
+        'orderby'        => 'post_title',
+        'order'          => 'ASC'
+    );
+    $the_query = new WP_Query( $args );
+
+    $posts = $the_query->posts;
+
+?>
+
+
+<div class="bg-grey-card py-5">
+    <form role="search" id="search-form" method="get" class="search-form">
+        <button type="submit" class="d-none"></button>
+        <div class="container">
+            <h2 class="title-xxlarge mb-4">
+                Esplora tutti i luoghi
+            </h2>
+            <div>
+                <div class="cmp-input-search">
+                    <div class="form-group autocomplete-wrapper mb-0">
+                        <div class="input-group">
+                            <label for="autocomplete-two" class="visually-hidden">Cerca</label>
+                            <input type="search" class="autocomplete form-control" placeholder="Cerca per parola chiave"
+                                id="autocomplete-two" name="search" value="<?php echo $query; ?>"
+                                data-bs-autocomplete="[]" />
+                            <div class="input-group-append">
+                                <button class="btn btn-primary" type="submit" id="button-3">
+                                    Invio
+                                </button>
+                            </div>
+                            <span class="autocomplete-icon" aria-hidden="true"><svg class="icon icon-sm icon-primary"
+                                    role="img" aria-labelledby="autocomplete-label">
+                                    <use href="#it-search"></use>
+                                </svg>
+                            </span>
+                        </div>
+                        <p id="autocomplete-label" class="u-grey-light text-paragraph-card mt-2 mb-30 mt-lg-3 mb-lg-40">
+                            <?php echo $the_query->found_posts; ?> luoghi trovati in ordine alfabetico
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="row g-4" id="load-more">
+                <?php
+                foreach ( $posts as $post ) {
+                    $load_card_type = 'luogo';
+                    get_template_part('template-parts/luogo/card-full');
+                }
+                ?>
+            </div>
+            <?php get_template_part("template-parts/search/more-results"); ?>
+        </div>
+    </form>
+</div>
+<?php wp_reset_query(); ?>

--- a/template-parts/vivere-comune/luoghi.php
+++ b/template-parts/vivere-comune/luoghi.php
@@ -20,7 +20,7 @@
                 }
             ?>
             <div class="d-flex justify-content-end">
-                <a href="#" class="btn btn-outline-primary full-mb" aria-label="aria-label" data-element="live-button-locations">
+                <a href="/vivere-il-comune/luoghi/" class="btn btn-outline-primary full-mb" aria-label="aria-label" data-element="live-button-locations">
                     Tutti i luoghi 
                     <svg class="icon icon-primary icon-xs ml-10">
                       <use href="#it-arrow-right"></use>


### PR DESCRIPTION
Realizzato il nuovo template per "Tutti i luoghi".

## Descrizione

Nel dettaglio:

- aggiunto il template "Tutti i luoghi"
https://comune.totolabs.it/vivere-il-comune/luoghi/
- aggiunta la scheda "Luoghi" nel pannello di configurazione del tema", con possibilità di impostare immagine/banner e didascali "hero" e luoghi in evidenza
![image](https://github.com/italia/design-comuni-wordpress-theme/assets/109132513/82417d74-65b3-45a2-a3e1-3153822c00a3)
- aggiunte le relative card previste per una corretta visualizzazione dei luoghi
- aggiunta la pagina "I luoghi" tra le pagine predefinite, la quale utilizza il template creato
- modificato il collegamento nella pagina "Vivere il comune" del pulsante "Tutti i luoghi" con l'aggiunta della nuova pagina
https://comune.totolabs.it/vivere-il-comune/

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->