### PR TITLE
fix: Json pagine predefinite

### DIFF
--- a/inc/comuni_pagine.json
+++ b/inc/comuni_pagine.json
@@ -105,15 +105,14 @@
       "slug": "domande-frequenti",
       "description": "Elenco di risposte alle domande più frequenti raccolte dalle richieste di assistenza dei cittadini.",
       "template_name": "domande-frequenti",
-      "children": {
-		  "Tutti i luoghi": {
-          "title": "I luoghi",
-          "slug": "luoghi",
-          "description": "Tutti i luoghi d’interesse per scoprire il territorio comunale.",
-          "template_name": "luoghi",
-          "children": {}
-		  
-	  }
+      "children": {}
+    },
+    "Tutti i luoghi": {
+      "title": "I luoghi",
+      "slug": "luoghi",
+      "description": "Tutti i luoghi d’interesse per scoprire il territorio comunale.",
+      "template_name": "luoghi",
+      "children": {}
     }
   }
 }

--- a/inc/comuni_pagine.json
+++ b/inc/comuni_pagine.json
@@ -91,7 +91,15 @@
       "slug": "vivere-il-comune",
       "description": "Tutti gli eventi, le iniziative e i luoghi d’interesse per scoprire e vivere il territorio comunale.",
       "template_name": "vivere-il-comune",
-      "children": {}
+      "children": {
+        "Tutti i luoghi": {
+          "title": "Luoghi",
+          "slug": "luoghi",
+          "description": "Tutti i luoghi d’interesse per scoprire il territorio comunale.",
+          "template_name": "luoghi",
+          "children": {}
+        }
+      }
     },
     "Argomenti": {
       "title": "Argomenti",
@@ -105,13 +113,6 @@
       "slug": "domande-frequenti",
       "description": "Elenco di risposte alle domande più frequenti raccolte dalle richieste di assistenza dei cittadini.",
       "template_name": "domande-frequenti",
-      "children": {}
-    },
-    "Tutti i luoghi": {
-      "title": "I luoghi",
-      "slug": "luoghi",
-      "description": "Tutti i luoghi d’interesse per scoprire il territorio comunale.",
-      "template_name": "luoghi",
       "children": {}
     }
   }


### PR DESCRIPTION
## Descrizione

Nella v1.10.0, il formato del JSON che dichiara l lista delle pagine predefinite non è corretto: viene restituita una lista nulla, e dunque le pagine predefinite 1) non sono create in una nuova installazione, o 2) non sono riconosciute in una installazione esistente.
La PR corregge il file, e ripristina le funzionalità che ne dipendono.

Fixes #439

## Checklist

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).