### PR TITLE
Quickfix: alcuni piccoli bug

### DIFF
--- a/inc/utils.php
+++ b/inc/utils.php
@@ -1086,12 +1086,12 @@ if(!function_exists("dci_get_related_unita_amministrative")) {
             );
         }
 
-        $servizi =  get_posts( $args );
+        $id_servizi =  get_posts( $args );
 
         $unita_organizzative = array();
 
-        foreach ($servizi as $servizio) {
-            $id = dci_get_meta('unita_responsabile', '_dci_servizio_', $servizio -> ID);
+        foreach ($id_servizi as $id_servizio) {
+            $id = dci_get_meta('unita_responsabile', '_dci_servizio_', $id_servizio);
 
             if (!dci_contains_element_with($unita_organizzative, $key= 'id', $value = $id)){
                 $unita_organizzative [] = array(

--- a/single-documento_pubblico.php
+++ b/single-documento_pubblico.php
@@ -362,9 +362,8 @@ get_header();
                             <section id="documenti_collegati" class="it-page-section mb-5">
                                 <h4>Documenti collegati</h4>
                                 <div class="card-wrapper card-teaser-wrapper card-teaser-wrapper-equal">
-                                    <?php foreach ($documenti_collegati as $all_url) {
-                                        $all_id = attachment_url_to_postid($all_url);
-                                        $documento = get_post($all_id);
+                                    <?php foreach ($documenti_collegati as $documento_id) {
+                                        $documento = get_post($documento_id);
                                         $with_border = true;
                                         get_template_part("template-parts/documento/card");
                                     } ?>

--- a/template-parts/domanda-frequente/item.php
+++ b/template-parts/domanda-frequente/item.php
@@ -1,7 +1,7 @@
 <?php
 global $i;
 
-$description = dci_get_meta('risposta'); 
+$description = dci_get_meta('risposta', '_dci_domanda_frequente_', $post->ID);
 ?>
 
 


### PR DESCRIPTION
## Descrizione
Correzioni veloci per risolvere alcuni bug minori segnalati tempo fa, e tuttora presenti.

#### Fixes #287 (Lista FAQ senza risposte)
Il _postmeta_ "risposta" non viene prelevato.

#### Fixes #294, Fixes #430 (Documenti correlati in Documento Pubblico)
`$documenti_collegati` è già in origine un array di post ID, e non di url che debbano essere convertiti in post.
Nel loop si ottiene sempre un `get_post(null)`, cioè sempre il documento corrente.

#### Fixes #348 (UO non mostrate nei servizi)
Piccolo bug in `dci_get_related_unita_amministrative()`.
Prima [qui preleva i servizi come lista di ID](https://github.com/italia/design-comuni-wordpress-theme/blob/80f7c859163b19a3e8861596a1bca57d1422bf48/inc/utils.php#L1067), e poi [qui li usa come oggetti post](https://github.com/italia/design-comuni-wordpress-theme/blob/80f7c859163b19a3e8861596a1bca57d1422bf48/inc/utils.php#L1094).


## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).