### PR TITLE
Fix: Creazione pagine predefinite

### DIFF
--- a/inc/activation.php
+++ b/inc/activation.php
@@ -485,7 +485,7 @@ function dci_create_page_template($name, $slug, $template, $parent_id = '', $con
         'post_content' => $new_page_content,
         'post_status'  => 'publish',
         'post_author'  => 1,
-        'post_slug' => $slug,
+        'post_name' => $slug,
         'post_parent' => $parent_id
     );
 

--- a/inc/activation.php
+++ b/inc/activation.php
@@ -476,7 +476,7 @@ function dci_create_page_template($name, $slug, $template, $parent_id = '', $con
 
     $new_page_title    = $name;
     $new_page_content  = $content;
-    $new_page_template = 'page-templates/'.$template.'.php';
+    $new_page_template = $template ? 'page-templates/'.$template.'.php' : '';
     $page_check        = get_page_by_title( $new_page_title);
 
     $new_page = array(


### PR DESCRIPTION
## Descrizione

Correzioni all'assegnazione di template e slug delle pagine predefinite.

---

La procedura che crea le pagine predefinite configurate in [comuni_pagine.json](https://github.com/italia/design-comuni-wordpress-theme/blob/main/inc/comuni_pagine.json) ha questi difetti:
1) se non hanno un template assegnato, gli viene attribuito un template "rotto" (invece di nessun template);
2) lo slug dichiarato non viene in realtà applicato, viene ignorato e se ne assegna uno formato a partire dal titolo.[^1]

[^1]: A volte lo slug risulta uguale o simile, ma non sempre.  [ "post_slug" non è un parametro di wp_insert_post() ]

Fixes #425 

## Checklist

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
