### PR TITLE
Vari warning php  

### DIFF
--- a/inc/admin/page.php
+++ b/inc/admin/page.php
@@ -50,7 +50,6 @@ function dci_add_page_metaboxes() {
             return;
         }
 
-        $curr_page_id = $_GET['post'];
         $slug = get_post_field( 'post_name', $curr_page_id );
 
         // Get the name of the Page Template file.

--- a/inc/comuni_config.php
+++ b/inc/comuni_config.php
@@ -54,11 +54,7 @@ function dci_get_tipologie_related_to_taxonomy($taxonomy) {
  * restituisce tutti i nomi delle tipologie del Sito dei Comuni
  */
 function dci_get_tipologie_names() {
-    $result = array();
-    foreach (COMUNI_TIPOLOGIE as $tipologia) {
-        $result[] = $tipologia['name'];
-    }
-    return $result;
+    return array_column(COMUNI_TIPOLOGIE, 'name');
 }
 
 /**
@@ -66,11 +62,7 @@ function dci_get_tipologie_names() {
  */
 
 function dci_get_tipologie_prefixes(){
-    $result = array();
-    foreach (COMUNI_TIPOLOGIE as $tipologia) {
-        $result[$tipologia['name']] = $tipologia['prefix'];
-    }
-    return $result;
+    return array_column(COMUNI_TIPOLOGIE, 'prefix', 'name');
 }
 
 
@@ -79,11 +71,7 @@ function dci_get_tipologie_prefixes(){
  * restituisce tuttle capability dei custom types del Sito dei Comuni
  */
 function dci_get_tipologie_capabilities(){
-    $result = array();
-    foreach (COMUNI_TIPOLOGIE as $tipologia) {
-        $result[] = $tipologia['capability'];
-    }
-    return $result;
+    return array_column(COMUNI_TIPOLOGIE, 'capability', 'name');
 }
 
 /**

--- a/inc/comuni_tipologie.json
+++ b/inc/comuni_tipologie.json
@@ -181,11 +181,6 @@
             "prefix" : "_dci_domanda_frequente_",
             "singular_name" : "Domanda Frequente",
             "plural_name" : "FAQ"
-        },
-        "page": {
-            "name" : "page",
-            "singular_name" : "Pagina",
-            "plural_name" : "Pagine"
         }
     }
 }

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -354,7 +354,7 @@ if(!function_exists("dci_get_current_group")) {
             if (!empty($postTypeArray) && count($postTypeArray) === 1) {
                 $tipo_post = reset($postTypeArray);
             }
-            return  dci_get_group($tipo_post);
+            return !empty($tipo_post) ? dci_get_group($tipo_post) : null;
         }
 
         if (is_author()) {

--- a/template-parts/home/messages.php
+++ b/template-parts/home/messages.php
@@ -2,7 +2,7 @@
 <?php foreach($messages as $message): ?>
     <?php
 
-    if(trim($message['testo_message']) == "") continue;
+    if ( empty($message['testo_message']) || trim($message['testo_message']) == "" ) continue;
     $message_date = strtotime($message['data_message'] ?? '');
     $now = strtotime("now");
     $color = $message['colore_message'] == 'yellow' ? 'black' : 'white';
@@ -11,7 +11,7 @@
     <div class="p-3 home-message <?php echo $message['colore_message'] ?>">
         <div class="home-message-content">
             <p class="msg">
-                <?php if($message['icona_message']): ?>
+                <?php if ( !empty($message['icona_message']) ): ?>
                 <svg id="alert" viewBox="0 0 492.963 492.963">
                     <path d="M246.458,169.582c-11.5,0-19.1,9.6-19.1,19.1v114.8c0,11.5,7.6,19.101,19.1,19.101s19.101-9.601,19.101-19.101v-114.8C265.559,177.182,257.958,169.582,246.458,169.582z"/>
                     <circle cx="246.458" cy="379.982" r="19.1"/>
@@ -19,7 +19,7 @@
                 </svg>
                 <?php endif; ?>
                 <?php echo nl2br($message['testo_message']) ?>
-                <?php if($message['link_message']): ?>
+                <?php if ( !empty($message['link_message']) ) : ?>
                     <a href="<?php echo $message['link_message']; ?>" class="btn btn-sm btn-outline-<?php echo $color; ?> ms-3">Dettagli</a>
                 <?php endif; ?>
             </p>

--- a/template-parts/search/filters-modal.php
+++ b/template-parts/search/filters-modal.php
@@ -42,6 +42,11 @@ aria-labelledby="modalrightTitle"
                             <?php 
                                 foreach ($tipologie as $type_slug) {
                                     $tipologia = get_term_by('slug', $type_slug);
+
+                                    $plural_name = COMUNI_TIPOLOGIE[$type_slug]['plural_name'] ?? '';
+                                    if ( !$plural_name && post_type_exists( $type_slug ) ) {
+                                        $plural_name = get_post_type_object( $type_slug )->labels->name;
+                                    }
                             ?>
                             <li>
                                 <div class="form-check">
@@ -57,7 +62,7 @@ aria-labelledby="modalrightTitle"
                                     <label
                                         for="mobile-<?php echo $type_slug; ?>" 
                                         class="subtitle-small_semi-bold mb-0 category-list__list"
-                                        ><?php echo COMUNI_TIPOLOGIE[$type_slug]['plural_name']; ?>
+                                        ><?php echo $plural_name; ?>
                                         </label
                                     >
                                     </div>


### PR DESCRIPTION
## Descrizione

Risolve alcuni warning php segnalati in vecchi issue, e certi difetti correlati.

Fixes #267, fixes #302, fixes #449.

Inoltre, risolve i warning introdotti con la #349, descritti [qui](https://github.com/italia/design-comuni-wordpress-theme/issues/271#issuecomment-1729338428).

### Checklist
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).