### PR TITLE
fix: Escaping stringhe query ricerche

### DIFF
--- a/page-templates/domande-frequenti.php
+++ b/page-templates/domande-frequenti.php
@@ -67,7 +67,7 @@ get_header();
                                 placeholder="Cerca" 
                                 id="autocomplete-three" 
                                 name="search"
-                                value="<?php echo $query; ?>"
+                                value="<?php echo esc_attr($query); ?>"
                                 data-bs-autocomplete="[]">
                                 <div class="input-group-append">
                                     <button class="btn btn-primary" type="submit" id="button-3">

--- a/taxonomy-categorie_servizio.php
+++ b/taxonomy-categorie_servizio.php
@@ -57,7 +57,7 @@ get_header();
                     placeholder="Cerca una parola chiave"
                     id="autocomplete-two"
                     name="search"
-                    value="<?php echo $query; ?>"
+                    value="<?php echo esc_attr($query); ?>"
                     data-bs-autocomplete="[]">
                   <div class="input-group-append">
                       <button class="btn btn-primary" type="submit" id="button-3">

--- a/template-parts/documento/tutti-documenti.php
+++ b/template-parts/documento/tutti-documenti.php
@@ -30,7 +30,7 @@ global $the_query, $load_posts, $load_card_type;
             <div class="input-group">
               <label for="autocomplete-two" class="visually-hidden">Cerca</label>
               <input type="search" class="autocomplete form-control" placeholder="Cerca per parola chiave"
-                id="autocomplete-two" name="search" value="<?php echo $query; ?>" data-bs-autocomplete="[]" />
+                id="autocomplete-two" name="search" value="<?php echo esc_attr($query); ?>" data-bs-autocomplete="[]" />
               <div class="input-group-append">
                 <button class="btn btn-primary" type="submit" id="button-3">
                   Invio

--- a/template-parts/evento/tutti-eventi.php
+++ b/template-parts/evento/tutti-eventi.php
@@ -32,7 +32,7 @@ global $the_query, $load_posts, $load_card_type;
                         <div class="input-group">
                             <label for="autocomplete-two" class="visually-hidden">Cerca</label>
                             <input type="search" class="autocomplete form-control" placeholder="Cerca per parola chiave"
-                                id="autocomplete-two" name="search" value="<?php echo $query; ?>"
+                                id="autocomplete-two" name="search" value="<?php echo esc_attr($query); ?>"
                                 data-bs-autocomplete="[]" />
                             <div class="input-group-append">
                                 <button class="btn btn-primary" type="submit" id="button-3">

--- a/template-parts/luogo/tutti-luoghi.php
+++ b/template-parts/luogo/tutti-luoghi.php
@@ -32,7 +32,7 @@ global $the_query, $load_posts, $load_card_type;
                         <div class="input-group">
                             <label for="autocomplete-two" class="visually-hidden">Cerca</label>
                             <input type="search" class="autocomplete form-control" placeholder="Cerca per parola chiave"
-                                id="autocomplete-two" name="search" value="<?php echo $query; ?>"
+                                id="autocomplete-two" name="search" value="<?php echo esc_attr($query); ?>"
                                 data-bs-autocomplete="[]" />
                             <div class="input-group-append">
                                 <button class="btn btn-primary" type="submit" id="button-3">

--- a/template-parts/novita/tutte-novita.php
+++ b/template-parts/novita/tutte-novita.php
@@ -40,7 +40,7 @@ global $the_query, $load_posts, $load_card_type;
                         <div class="input-group">
                             <label for="autocomplete-two" class="visually-hidden">Cerca</label>
                             <input type="search" class="autocomplete form-control" placeholder="Cerca per parola chiave"
-                                id="autocomplete-two" name="search" value="<?php echo $query; ?>"
+                                id="autocomplete-two" name="search" value="<?php echo esc_attr($query); ?>"
                                 data-bs-autocomplete="[]" />
                             <div class="input-group-append">
                                 <button class="btn btn-primary" type="submit" id="button-3">

--- a/template-parts/servizio/tutti-servizi.php
+++ b/template-parts/servizio/tutti-servizi.php
@@ -46,7 +46,7 @@
                         placeholder="Cerca una parola chiave"
                         id="autocomplete-two"
                         name="search"
-                        value="<?php echo $query; ?>"
+                        value="<?php echo esc_attr($query); ?>"
                         data-bs-autocomplete="[]"
                         />
                         <div class="input-group-append">


### PR DESCRIPTION
## Descrizione

Escape dei campi di ricerca.

Per prevenzione XSS.
Nei template con ricerche, il valore di una ricerca eseguita non è né sanificato né passato per un escape, quando è riportato nell'html del campo input.

Fixes #465 

## Checklist

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).