### PR TITLE
fix(privacy): disable WordPress default emoji remote loading from s.w.org

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -175,7 +175,10 @@ if ( ! function_exists( 'dci_disable_wp_emojis' ) ) :
 		// impedisce anche il DNS-prefetch di s.w.org iniettato in
 		// wp_resource_hints: la sola remove_action sopra non basta a
 		// rimuovere `<link rel="dns-prefetch" href="//s.w.org">`.
-		add_filter( 'wp_resource_hints', 'dci_remove_s_w_org_prefetch', 10, 2 );
+		// Priority 999 per assicurare che il filter giri per ultimo,
+		// anche se un plugin di terze parti aggiunge s.w.org con
+		// priority superiore al default 10.
+		add_filter( 'wp_resource_hints', 'dci_remove_s_w_org_prefetch', 999, 2 );
 	}
 endif;
 add_action( 'init', 'dci_disable_wp_emojis' );

--- a/functions.php
+++ b/functions.php
@@ -152,6 +152,47 @@ function dci_widgets_init() {
 add_action( 'widgets_init', 'dci_widgets_init' );
 
 /**
+ * Disabilita il caricamento remoto degli emoji di default di WordPress
+ * (s.w.org/images/core/emoji/...), che sarebbe altrimenti eseguito al
+ * primo pixel di ogni pagina pubblica e comporterebbe un trasferimento
+ * di dati personali (indirizzo IP del visitatore) verso Automattic Inc.
+ * (USA) senza informativa e senza consenso.
+ *
+ * Gli emoji restano supportati nativamente da tutti i browser moderni:
+ * la rimozione del polyfill non ha impatto sull'esperienza utente.
+ *
+ * @see https://developer.wordpress.org/reference/functions/wp_head/
+ */
+if ( ! function_exists( 'dci_disable_wp_emojis' ) ) :
+	function dci_disable_wp_emojis() {
+		remove_action( 'wp_head',             'print_emoji_detection_script', 7 );
+		remove_action( 'admin_print_scripts', 'print_emoji_detection_script'    );
+		remove_action( 'wp_print_styles',     'print_emoji_styles'              );
+		remove_action( 'admin_print_styles',  'print_emoji_styles'              );
+		remove_filter( 'the_content_feed',    'wp_staticize_emoji'              );
+		remove_filter( 'comment_text_rss',    'wp_staticize_emoji'              );
+		remove_filter( 'wp_mail',             'wp_staticize_emoji_for_email'    );
+		// impedisce anche il DNS-prefetch di s.w.org iniettato in
+		// wp_resource_hints: la sola remove_action sopra non basta a
+		// rimuovere `<link rel="dns-prefetch" href="//s.w.org">`.
+		add_filter( 'wp_resource_hints', 'dci_remove_s_w_org_prefetch', 10, 2 );
+	}
+	add_action( 'init', 'dci_disable_wp_emojis' );
+endif;
+
+if ( ! function_exists( 'dci_remove_s_w_org_prefetch' ) ) :
+	function dci_remove_s_w_org_prefetch( $urls, $relation_type ) {
+		if ( 'dns-prefetch' !== $relation_type ) {
+			return $urls;
+		}
+		return array_values( array_filter( $urls, function ( $u ) {
+			$href = is_array( $u ) ? ( isset( $u['href'] ) ? $u['href'] : '' ) : $u;
+			return strpos( $href, 's.w.org' ) === false;
+		} ) );
+	}
+endif;
+
+/**
  * Enqueue scripts and styles.
  */
 function dci_scripts() {

--- a/functions.php
+++ b/functions.php
@@ -161,7 +161,7 @@ add_action( 'widgets_init', 'dci_widgets_init' );
  * Gli emoji restano supportati nativamente da tutti i browser moderni:
  * la rimozione del polyfill non ha impatto sull'esperienza utente.
  *
- * @see https://developer.wordpress.org/reference/functions/wp_head/
+ * @see https://developer.wordpress.org/reference/functions/print_emoji_detection_script/
  */
 if ( ! function_exists( 'dci_disable_wp_emojis' ) ) :
 	function dci_disable_wp_emojis() {
@@ -177,8 +177,8 @@ if ( ! function_exists( 'dci_disable_wp_emojis' ) ) :
 		// rimuovere `<link rel="dns-prefetch" href="//s.w.org">`.
 		add_filter( 'wp_resource_hints', 'dci_remove_s_w_org_prefetch', 10, 2 );
 	}
-	add_action( 'init', 'dci_disable_wp_emojis' );
 endif;
+add_action( 'init', 'dci_disable_wp_emojis' );
 
 if ( ! function_exists( 'dci_remove_s_w_org_prefetch' ) ) :
 	function dci_remove_s_w_org_prefetch( $urls, $relation_type ) {


### PR DESCRIPTION
## Motivazione

WordPress carica per default risorse per la conversione degli emoji sui browser che non li supportano nativamente: uno script inline (`print_emoji_detection_script`) che a runtime effettua richieste HTTP verso `https://s.w.org/images/core/emoji/…` (Automattic Inc., USA), più un `<link rel="dns-prefetch" href="//s.w.org">` iniettato in `wp_head`.

Dal punto di vista GDPR:

- Il DNS-prefetch avviene al primo pixel, prima di qualunque interazione.
- Il polyfill JavaScript può trasmettere l'IP del visitatore ad Automattic Inc. (USA), soggetto a Cloud Act statunitense.
- Nessuna informativa privacy dei siti erogati con il tema documenta questo trasferimento.
- I browser moderni target del design system supportano gli emoji nativamente: il polyfill è ridondante.

Il tema, pur curato per il design AgID, **non disabilita questo comportamento di default di WordPress**. La responsabilità ricade sul singolo comune amministratore, che nella quasi totalità dei casi non è consapevole del comportamento.

## Dati da rilevazione indipendente

Su **1053 installazioni** del tema (parent/child/fork), rilevate su un dump IPA aggiornato al 23/07/2026:

- **293 installazioni (28%)** caricano risorse da `s.w.org/images/core/…` al primo caricamento della pagina pubblica di segnalazione/contatto.

La correzione qui proposta rimuove il comportamento indesiderato **una volta per tutte** le installazioni che aggiorneranno il tema, senza richiedere azione da parte del singolo comune.

## Cosa cambia

Un solo file: `functions.php`. Aggiunge due funzioni che disattivano:

1. lo script di detection nel front-end e nell'admin;
2. gli stili emoji nel front-end e nell'admin;
3. i filtri di sostituzione emoji nei feed RSS e nelle email;
4. il DNS-prefetch di `s.w.org` iniettato in `wp_resource_hints`.

Il quarto punto è particolarmente importante: la sola `remove_action` sul detection script **non rimuove** il `<link rel="dns-prefetch">`, che è prodotto separatamente dal core WP tramite `wp_resource_hints`. Serve un filter esplicito che rimuova gli URL contenenti `s.w.org` dalla lista.

## Test manuale

1. Applicare il tema patchato su una installazione WordPress vuota.
2. Aprire una pagina qualsiasi in modalità incognito.
3. `view-source:` della pagina — verificare:
   - nessuno `<script>` inline che contenga `wpemoji`/`twemoji.min.js`;
   - nessun `<link rel='dns-prefetch' href='//s.w.org'>`.
4. DevTools → Network, filtrare `s.w.org`: nessuna richiesta.
5. Verificare che i caratteri emoji Unicode restino visibili nel contenuto (test con \"🇮🇹 ✅ ⚠️\").

## Backward compatibility

- Nessuna breaking change: i caratteri emoji Unicode restano visibili nativamente su qualunque browser corrente.
- Nessuna dipendenza aggiunta.
- Le funzioni sono avvolte in `if ( ! function_exists( ... ) )` per non collidere con eventuali override.
- Se ritenuto troppo invasivo come default, sono disponibile a proporre variante `opt-out` con checkbox nella pagina Welcome del tema.

## Riferimenti

- WP Reference `remove_action` per emoji: <https://developer.wordpress.org/reference/hooks/wp_head/>
- Automattic Privacy Policy (destinatario dei dati emoji-service): <https://automattic.com/privacy/>

---

Contributo offerto in buona fede e senza alcun onere, nell'ambito di una rilevazione tecnica indipendente sui siti dei comuni italiani.